### PR TITLE
fix NoSuchMethodError

### DIFF
--- a/celements-model/src/main/java/com/celements/model/classes/fields/list/ListField.java
+++ b/celements-model/src/main/java/com/celements/model/classes/fields/list/ListField.java
@@ -33,6 +33,27 @@ public abstract class ListField<T> extends AbstractListField<List<T>, T> {
       return getThis();
     }
 
+    // XXX can be removed once all projects include the celements-model 1.2+, but for now
+    // override needed for backwards compatibility with older version to avoid NoSuchMethodError
+    @Override
+    public B size(@Nullable Integer val) {
+      return super.size(val);
+    }
+
+    // XXX can be removed once all projects include the celements-model 1.2+, but for now
+    // override needed for backwards compatibility with older version to avoid NoSuchMethodError
+    @Override
+    public B displayType(@Nullable String val) {
+      return super.displayType(val);
+    }
+
+    // XXX can be removed once all projects include the celements-model 1.2+, but for now
+    // override needed for backwards compatibility with older version to avoid NoSuchMethodError
+    @Override
+    public B picker(@Nullable Boolean val) {
+      return super.picker(val);
+    }
+
     public B separator(@Nullable String val) {
       separator = val;
       return getThis();

--- a/celements-model/src/main/java/com/celements/model/classes/fields/list/StaticListField.java
+++ b/celements-model/src/main/java/com/celements/model/classes/fields/list/StaticListField.java
@@ -14,8 +14,8 @@ public final class StaticListField extends StringListField {
       super(classDefName, name);
     }
 
-    // override needed for backwards compatibility with older version to avoid NoSuchMethodError:
-    // com.celements.model.classes.fields.list.StaticListField$Builder.values(Ljava/util/List;)
+    // XXX can be removed once all projects include the celements-model dependency, but for now
+    // override needed for backwards compatibility with older version to avoid NoSuchMethodError
     @Override
     public Builder values(List<String> values) {
       return super.values(values);


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-610 caused issues because I moved some methods to the superclass, but when instantiating via reflection it still expects it in the subclass if the dependency is not updated in all projects