### PR TITLE
CelementsIdComputer change computeId behaviour

### DIFF
--- a/celements-model/src/main/java/com/celements/store/id/CelementsIdComputer.java
+++ b/celements-model/src/main/java/com/celements/store/id/CelementsIdComputer.java
@@ -23,6 +23,15 @@ public interface CelementsIdComputer {
       throws IdComputationException;
 
   /**
+   * @return computes the maximum id (regarding collision detection) for the given document and
+   *         language
+   * @throws IdComputationException
+   *           if unable to compute an id
+   */
+  long computeMaxDocumentId(@NotNull DocumentReference docRef, @Nullable String lang)
+      throws IdComputationException;
+
+  /**
    * @return computes the id for the given document, language and collision count
    * @throws IdComputationException
    *           if unable to compute an id

--- a/celements-model/src/main/java/com/celements/store/id/UniqueHashIdComputer.java
+++ b/celements-model/src/main/java/com/celements/store/id/UniqueHashIdComputer.java
@@ -89,12 +89,14 @@ public class UniqueHashIdComputer implements CelementsIdComputer {
     verifyCount(collisionCount, BITS_COLLISION_COUNT);
     verifyCount(objectCount, BITS_OBJECT_COUNT);
     long docId = hashMD5(serializeLocalUid(docRef, lang));
-    long center = andifyLeft(andifyRight(docId, BITS_OBJECT_COUNT), BITS_COLLISION_COUNT);
-    byte bitsRight = 64 - BITS_COLLISION_COUNT;
-    long left = andifyRight(((long) collisionCount) << bitsRight, bitsRight);
-    byte bitsLeft = 64 - BITS_OBJECT_COUNT;
-    long right = andifyLeft(objectCount, bitsLeft);
-    return left & center & right;
+    long left = andifyRight(docId, (byte) (BITS_COLLISION_COUNT + BITS_OBJECT_COUNT));
+    long right = andifyLeft(collisionCount, inverseCount(BITS_COLLISION_COUNT));
+    right = (right << BITS_OBJECT_COUNT) + objectCount;
+    return left & right;
+  }
+
+  private byte inverseCount(byte count) {
+    return (byte) (64 - count);
   }
 
   long andifyLeft(long base, byte bits) {

--- a/celements-model/src/test/java/com/celements/store/id/UniqueHashIdComputerTest.java
+++ b/celements-model/src/test/java/com/celements/store/id/UniqueHashIdComputerTest.java
@@ -69,10 +69,10 @@ public class UniqueHashIdComputerTest extends AbstractComponentTest {
   @Test
   public void test_computeId_collisionCount() throws Exception {
     // full md5: 0xf0da7f3f8545ded5L
-    assertEquals(0x30da7f3f8545ded5L, idComputer.computeId(docRef, lang, (byte) 0b00, 0xed5));
-    assertEquals(0x70da7f3f8545ded5L, idComputer.computeId(docRef, lang, (byte) 0b01, 0xed5));
-    assertEquals(0xb0da7f3f8545ded5L, idComputer.computeId(docRef, lang, (byte) 0b10, 0xed5));
-    assertEquals(0xf0da7f3f8545ded5L, idComputer.computeId(docRef, lang, (byte) 0b11, 0xed5));
+    assertEquals(0xf0da7f3f8545ced5L, idComputer.computeId(docRef, lang, (byte) 0b00, 0xed5));
+    assertEquals(0xf0da7f3f8545ded5L, idComputer.computeId(docRef, lang, (byte) 0b01, 0xed5));
+    assertEquals(0xf0da7f3f8545eed5L, idComputer.computeId(docRef, lang, (byte) 0b10, 0xed5));
+    assertEquals(0xf0da7f3f8545fed5L, idComputer.computeId(docRef, lang, (byte) 0b11, 0xed5));
   }
 
   @Test
@@ -104,11 +104,11 @@ public class UniqueHashIdComputerTest extends AbstractComponentTest {
   @Test
   public void test_computeId_objectCount() throws Exception {
     // full md5: 0xf0da7f3f8545ded5L
-    assertEquals(0xf0da7f3f8545d000L, idComputer.computeId(docRef, lang, (byte) 0b11, 0));
-    assertEquals(0xf0da7f3f8545d005L, idComputer.computeId(docRef, lang, (byte) 0b11, 5));
-    assertEquals(0xf0da7f3f8545ded5L, idComputer.computeId(docRef, lang, (byte) 0b11, 0xed5));
-    assertEquals(0xf0da7f3f8545d0a0L, idComputer.computeId(docRef, lang, (byte) 0b11, 0xa0));
-    assertEquals(0xf0da7f3f8545dfffL, idComputer.computeId(docRef, lang, (byte) 0b11, 0xfff));
+    assertEquals(0xf0da7f3f8545d000L, idComputer.computeId(docRef, lang, (byte) 0b01, 0));
+    assertEquals(0xf0da7f3f8545d005L, idComputer.computeId(docRef, lang, (byte) 0b01, 5));
+    assertEquals(0xf0da7f3f8545ded5L, idComputer.computeId(docRef, lang, (byte) 0b01, 0xed5));
+    assertEquals(0xf0da7f3f8545d0a0L, idComputer.computeId(docRef, lang, (byte) 0b01, 0xa0));
+    assertEquals(0xf0da7f3f8545dfffL, idComputer.computeId(docRef, lang, (byte) 0b01, 0xfff));
   }
 
   @Test
@@ -139,13 +139,13 @@ public class UniqueHashIdComputerTest extends AbstractComponentTest {
 
   @Test
   public void test_computeDocumentId() throws Exception {
-    assertEquals(0x30da7f3f8545d000L, idComputer.computeDocumentId(docRef, lang));
-    assertEquals(0xb0da7f3f8545d000L, idComputer.computeDocumentId(docRef, lang, (byte) 0b10));
+    assertEquals(0xf0da7f3f8545c000L, idComputer.computeDocumentId(docRef, lang));
+    assertEquals(0xf0da7f3f8545d000L, idComputer.computeDocumentId(docRef, lang, (byte) 0b01));
   }
 
   @Test
   public void test_computeDocumentId_docRef() throws Exception {
-    long exp = 0x30da7f3f8545d000L;
+    long exp = 0xf0da7f3f8545c000L;
     assertEquals(exp, idComputer.computeDocumentId(docRef, lang));
     docRef.getWikiReference().setName("asdf");
     assertEquals(exp, idComputer.computeDocumentId(docRef, lang));
@@ -162,7 +162,7 @@ public class UniqueHashIdComputerTest extends AbstractComponentTest {
 
   @Test
   public void test_computeDocumentId_lang() throws Exception {
-    long exp = 0x2ec3dd404a0a3000L;
+    long exp = 0x6ec3dd404a0a0000L;
     assertEquals(exp, idComputer.computeDocumentId(docRef, ""));
     assertEquals(exp, idComputer.computeDocumentId(docRef, " "));
     assertEquals(exp, idComputer.computeDocumentId(docRef, null));
@@ -173,14 +173,14 @@ public class UniqueHashIdComputerTest extends AbstractComponentTest {
   public void test_computeDocumentId_doc() throws Exception {
     XWikiDocument doc = new XWikiDocument(docRef);
     doc.setLanguage(lang);
-    assertEquals(0x30da7f3f8545d000L, idComputer.computeDocumentId(doc));
+    assertEquals(0xf0da7f3f8545c000L, idComputer.computeDocumentId(doc));
   }
 
   @Test
   public void test_computeNextObjectId_noObj() throws Exception {
     XWikiDocument doc = new XWikiDocument(docRef);
     doc.setLanguage(lang);
-    long docId = 0x30da7f3f8545d000L;
+    long docId = 0xf0da7f3f8545c000L;
     assertEquals(docId + 1, idComputer.computeNextObjectId(doc));
     assertEquals(docId + 1, idComputer.computeNextObjectId(doc));
   }
@@ -189,7 +189,7 @@ public class UniqueHashIdComputerTest extends AbstractComponentTest {
   public void test_computeNextObjectId() throws Exception {
     XWikiDocument doc = new XWikiDocument(docRef);
     doc.setLanguage(lang);
-    long docId = 0x30da7f3f8545d000L;
+    long docId = 0xf0da7f3f8545c000L;
     assertEquals(docId + 1, addObjWithComputedId(doc).getId());
     assertEquals(docId + 2, addObjWithComputedId(doc).getId());
     assertEquals(docId + 3, addObjWithComputedId(doc).getId());
@@ -200,7 +200,7 @@ public class UniqueHashIdComputerTest extends AbstractComponentTest {
   public void test_computeNextObjectId_fill() throws Exception {
     XWikiDocument doc = new XWikiDocument(docRef);
     doc.setLanguage(lang);
-    long docId = 0x30da7f3f8545d000L;
+    long docId = 0xf0da7f3f8545c000L;
     BaseObject removeObj;
     assertEquals(docId + 1, addObjWithComputedId(doc).getId());
     assertEquals(docId + 2, (removeObj = addObjWithComputedId(doc)).getId());
@@ -214,7 +214,7 @@ public class UniqueHashIdComputerTest extends AbstractComponentTest {
   public void test_computeNextObjectId_ignoreOtherIdVersion() throws Exception {
     XWikiDocument doc = new XWikiDocument(docRef);
     doc.setLanguage(lang);
-    long docId = 0x30da7f3f8545d000L;
+    long docId = 0xf0da7f3f8545c000L;
     assertEquals(1, addObj(doc, 1, IdVersion.XWIKI_2).getId());
     assertEquals(docId + 1, addObjWithComputedId(doc).getId());
     assertEquals(2, addObj(doc, 2, IdVersion.XWIKI_2).getId());

--- a/celements-model/src/test/java/com/celements/store/id/UniqueHashIdComputerTest.java
+++ b/celements-model/src/test/java/com/celements/store/id/UniqueHashIdComputerTest.java
@@ -170,6 +170,11 @@ public class UniqueHashIdComputerTest extends AbstractComponentTest {
   }
 
   @Test
+  public void test_computeMaxDocumentId() throws Exception {
+    assertEquals(0xf0da7f3f8545f000L, idComputer.computeMaxDocumentId(docRef, lang));
+  }
+
+  @Test
   public void test_computeDocumentId_doc() throws Exception {
     XWikiDocument doc = new XWikiDocument(docRef);
     doc.setLanguage(lang);


### PR DESCRIPTION
redefined ID from `2bit | 50bit | 12bit` to `50bit | 2bit | 12bit` to allow a range select for collision detection in `loadXWikiDoc`
```
select XWD_ID from xwikidoc where XWD_ID >= :min and XWD_ID <= :max order by XWD_ID;
```
with `min = docBaseId`
and `max = min + (3 << 12)`

https://synjira.atlassian.net/browse/CELDEV-615