### PR TITLE
BaseCollectionIdColumnMigration / BaseElement / HibernateStore fixes

### DIFF
--- a/celements-model/src/main/java/com/celements/model/migration/BaseCollectionIdColumnMigration.java
+++ b/celements-model/src/main/java/com/celements/model/migration/BaseCollectionIdColumnMigration.java
@@ -34,7 +34,11 @@ public class BaseCollectionIdColumnMigration extends AbstractCelementsHibernateM
   public static final String NAME = "BaseCollectionIdColumnMigration";
 
   static final List<String> XWIKI_TABLES = ImmutableList.of("xwikiclasses", "xwikiclassesprop",
-      "xwikiobjects", "xwikiproperties", "xwikistatsdoc", "xwikistatsreferer", "xwikistatsvisit");
+      "xwikinumberclasses", "xwikibooleanclasses", "xwikistringclasses", "xwikidateclasses",
+      "xwikislistclasses", "xwikidblistclasses", "xwikiobjects", "xwikiproperties", "xwikiintegers",
+      "xwikilongs", "xwikifloats", "xwikidoubles", "xwikistrings", "xwikidates",
+      "xwikilargestrings", "xwikilists", "xwikilistitems", "xwikistatsdoc", "xwikistatsreferer",
+      "xwikistatsvisit");
 
   @Requirement
   private HibernateSessionFactory sessionFactory;

--- a/celements-model/src/main/java/com/celements/model/migration/BaseCollectionIdColumnMigration.java
+++ b/celements-model/src/main/java/com/celements/model/migration/BaseCollectionIdColumnMigration.java
@@ -35,10 +35,10 @@ public class BaseCollectionIdColumnMigration extends AbstractCelementsHibernateM
 
   static final List<String> XWIKI_TABLES = ImmutableList.of("xwikiobjects", "xwikiproperties",
       "xwikiintegers", "xwikilongs", "xwikifloats", "xwikidoubles", "xwikistrings", "xwikidates",
-      "xwikilargestrings", "xwikilists", "xwikilistitems", "xwikiclasses", "xwikiclassesprop",
-      "xwikinumberclasses", "xwikibooleanclasses", "xwikistringclasses", "xwikidateclasses",
-      "xwikislistclasses", "xwikidblistclasses", "xwikistatsdoc", "xwikistatsreferer",
-      "xwikistatsvisit");
+      "xwikilargestrings", "xwikilists", "xwikilistitems", "xwikistatsdoc", "xwikistatsreferer",
+      "xwikistatsvisit", "xwikiclasses", "xwikiclassesprop", "xwikinumberclasses",
+      "xwikibooleanclasses", "xwikistringclasses", "xwikidateclasses", "xwikislistclasses",
+      "xwikidblistclasses");
 
   @Requirement
   private HibernateSessionFactory sessionFactory;

--- a/celements-model/src/main/java/com/celements/model/migration/InformationSchema.java
+++ b/celements-model/src/main/java/com/celements/model/migration/InformationSchema.java
@@ -29,6 +29,10 @@ class InformationSchema {
     loadForeignKeys();
   }
 
+  public String getDatabase() {
+    return database;
+  }
+
   public TableSchemaData get(String table) throws IllegalArgumentException {
     if (map.containsKey(table)) {
       return map.get(table);
@@ -83,14 +87,14 @@ class InformationSchema {
     return Utils.getComponent(IQueryExecutionServiceRole.class).executeReadSql(String.class, sql);
   }
 
-  class TableSchemaData {
+  static class TableSchemaData {
 
     private final String tableName;
     private final String pkColumnName;
     private final String pkDataType;
     private final Map<String, ForeignKey> foreignKeys;
 
-    private TableSchemaData(String tableName, String pkColumnName, String pkDataType) {
+    TableSchemaData(String tableName, String pkColumnName, String pkDataType) {
       this.tableName = tableName;
       this.pkColumnName = pkColumnName;
       this.pkDataType = pkDataType;

--- a/celements-model/src/main/java/com/celements/store/part/CelHibernateStoreCollectionPart.java
+++ b/celements-model/src/main/java/com/celements/store/part/CelHibernateStoreCollectionPart.java
@@ -274,7 +274,7 @@ public class CelHibernateStoreCollectionPart {
                   object.getNumber() + ""), name };
               throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
                   XWikiException.ERROR_XWIKI_STORE_HIBERNATE_LOADING_OBJECT,
-                  "Exception while loading object '{0}' of class '{1}', number '{2}' and property '{3}'",
+                  "Exception while loading object [{0}] of class [{1}], number [{2}] and property '{3}'",
                   e, args);
             }
           }
@@ -291,7 +291,7 @@ public class CelHibernateStoreCollectionPart {
           + "") };
       throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
           XWikiException.ERROR_XWIKI_STORE_HIBERNATE_LOADING_OBJECT,
-          "Exception while loading object '{0}' of class '{1}' and number '{2}'", e, args);
+          "Exception while loading object [{0}] of class [{1}] and number [{2}]", e, args);
 
     } finally {
       try {

--- a/celements-model/src/main/java/com/celements/store/part/CelHibernateStoreCollectionPart.java
+++ b/celements-model/src/main/java/com/celements/store/part/CelHibernateStoreCollectionPart.java
@@ -119,10 +119,9 @@ public class CelHibernateStoreCollectionPart {
           String key = it.next();
           BaseProperty prop = (BaseProperty) object.getField(key);
           if (!prop.getName().equals(key)) {
-            Object[] args = { key, object.getName() };
             throw new XWikiException(XWikiException.MODULE_XWIKI_CLASSES,
-                XWikiException.ERROR_XWIKI_CLASSES_FIELD_INVALID,
-                "Field {0} in object {1} has an invalid name", null, args);
+                XWikiException.ERROR_XWIKI_CLASSES_FIELD_INVALID, "Field '" + key
+                    + "' has an invalid name in object: " + object);
           }
 
           String pname = prop.getName();
@@ -138,10 +137,9 @@ public class CelHibernateStoreCollectionPart {
     } catch (XWikiException xe) {
       throw xe;
     } catch (Exception e) {
-      Object[] args = { object.getName() };
       throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
           XWikiException.ERROR_XWIKI_STORE_HIBERNATE_SAVING_OBJECT,
-          "Exception while saving object {0}", e, args);
+          "Exception while saving object: " + object, e);
 
     } finally {
       try {
@@ -149,6 +147,7 @@ public class CelHibernateStoreCollectionPart {
           store.endTransaction(context, true);
         }
       } catch (Exception e) {
+        LOGGER.error("failed commit/rollback for {}", object, e);
       }
     }
     logXObject("saveXObject - end", object);
@@ -270,12 +269,9 @@ public class CelHibernateStoreCollectionPart {
                 throw e;
               }
             } catch (Throwable e2) {
-              Object[] args = { object.getName(), object.getClass(), Integer.valueOf(
-                  object.getNumber() + ""), name };
               throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
                   XWikiException.ERROR_XWIKI_STORE_HIBERNATE_LOADING_OBJECT,
-                  "Exception while loading object [{0}] of class [{1}], number [{2}] and property '{3}'",
-                  e, args);
+                  "Exception while loading property '" + name + "' for object: " + object, e);
             }
           }
 
@@ -287,11 +283,9 @@ public class CelHibernateStoreCollectionPart {
         store.endTransaction(context, false, false);
       }
     } catch (Exception e) {
-      Object[] args = { object.getName(), object.getClass(), Integer.valueOf(object.getNumber()
-          + "") };
       throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
           XWikiException.ERROR_XWIKI_STORE_HIBERNATE_LOADING_OBJECT,
-          "Exception while loading object [{0}] of class [{1}] and number [{2}]", e, args);
+          "Exception while loading object: " + object, e);
 
     } finally {
       try {
@@ -299,6 +293,7 @@ public class CelHibernateStoreCollectionPart {
           store.endTransaction(context, false, false);
         }
       } catch (Exception e) {
+        LOGGER.error("failed commit/rollback for {}", object, e);
       }
     }
     logXObject("loadXObject - end", object);
@@ -372,16 +367,16 @@ public class CelHibernateStoreCollectionPart {
         store.endTransaction(context, true);
       }
     } catch (Exception e) {
-      Object[] args = { object.getName() };
       throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
           XWikiException.ERROR_XWIKI_STORE_HIBERNATE_DELETING_OBJECT,
-          "Exception while deleting object {0}", e, args);
+          "Exception while deleting object: " + object, e);
     } finally {
       try {
         if (bTransaction) {
           store.endTransaction(context, false);
         }
       } catch (Exception e) {
+        LOGGER.error("failed commit/rollback for {}", object, e);
       }
     }
     logXObject("deleteXObject - end", object);
@@ -389,9 +384,7 @@ public class CelHibernateStoreCollectionPart {
 
   private void logXObject(String msg, BaseCollection obj) {
     if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug(msg + ": {}_{} {}_{}_{}", obj.getId(), obj.getIdVersion(),
-          store.getModelUtils().serializeRef(obj.getDocumentReference()),
-          store.getModelUtils().serializeRefLocal(obj.getXClassReference()), obj.getNumber());
+      LOGGER.debug("{}: {}", msg, obj);
     }
   }
 

--- a/celements-model/src/main/java/com/celements/store/part/CelHibernateStoreDocumentPart.java
+++ b/celements-model/src/main/java/com/celements/store/part/CelHibernateStoreDocumentPart.java
@@ -21,9 +21,6 @@ import org.xwiki.model.reference.WikiReference;
 
 import com.celements.store.CelHibernateStore;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicates;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.Iterables;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiAttachment;
@@ -431,6 +428,7 @@ public class CelHibernateStoreDocumentPart {
           store.endTransaction(context, false);
         }
       } catch (Exception e) {
+        LOGGER.error("failed commit/rollback for {}", doc, e);
       }
 
       // End monitoring timer
@@ -443,21 +441,8 @@ public class CelHibernateStoreDocumentPart {
 
   private void logXWikiDoc(String msg, XWikiDocument doc) {
     if (LOGGER.isInfoEnabled()) {
-      msg += ": {} {}";
-      List<String> objects = new ArrayList<>();
-      if (LOGGER.isTraceEnabled()) {
-        for (BaseObject obj : FluentIterable.from(Iterables.concat(
-            doc.getXObjects().values())).filter(Predicates.notNull())) {
-          if (obj.hasValidId()) {
-            objects.add(obj.getIdVersion() + "_" + obj.getId());
-          } else {
-            objects.add(obj.getId() + " " + obj.getGuid());
-          }
-        }
-        msg += " {}";
-      }
-      LOGGER.info(msg, doc.getId(), store.getModelUtils().serializeRef(doc.getDocumentReference()),
-          objects);
+      LOGGER.info(msg + ": {} {}", doc.getId(), store.getModelUtils().serializeRef(
+          doc.getDocumentReference()));
     }
   }
 

--- a/celements-model/src/test/java/com/celements/model/migration/BaseCollectionIdColumnMigrationTest.java
+++ b/celements-model/src/test/java/com/celements/model/migration/BaseCollectionIdColumnMigrationTest.java
@@ -93,15 +93,15 @@ public class BaseCollectionIdColumnMigrationTest extends AbstractComponentTest {
     expectModifyIdColumn(fkTable1);
     expectModifyFkLists();
     expect(queryExecMock.executeWriteSQL("alter table " + fkTable1 + " drop foreign key "
-        + fkName1)).andReturn(1).atLeastOnce();
+        + fkName1)).andReturn(1).once();
     expect(queryExecMock.executeWriteSQL("alter table " + fkTable2 + " drop foreign key "
-        + fkName2)).andReturn(1).atLeastOnce();
+        + fkName2)).andReturn(1).once();
     expect(queryExecMock.executeWriteSQL("alter table " + fkTable1 + " add constraint " + fkName1
         + " foreign key (XWI_ID,XWI_NAME) references " + table + " (XWP_ID,XWP_NAME)")).andReturn(
-            1).atLeastOnce();
+            1).once();
     expect(queryExecMock.executeWriteSQL("alter table " + fkTable2 + " add constraint " + fkName2
         + " foreign key (XWL_ID,XWL_NAME) references " + table + " (XWP_ID,XWP_NAME)")).andReturn(
-            1).atLeastOnce();
+            1).once();
   }
 
   private void expectModifyFkLists() throws XWikiException {
@@ -112,11 +112,11 @@ public class BaseCollectionIdColumnMigrationTest extends AbstractComponentTest {
     addForeignKey(fkName, fkTable, "XWL_NAME", table, "XWL_NAME");
     expectModifyIdColumn(table, 1);
     expect(queryExecMock.executeWriteSQL("alter table " + fkTable + " drop foreign key "
-        + fkName)).andReturn(1).atLeastOnce();
+        + fkName)).andReturn(1).once();
     expectModifyIdColumn("xwikilistitems");
     expect(queryExecMock.executeWriteSQL("alter table " + fkTable + " add constraint " + fkName
         + " foreign key (XWL_ID,XWL_NAME) references " + table + " (XWL_ID,XWL_NAME)")).andReturn(
-            1).atLeastOnce();
+            1).once();
   }
 
   @Test
@@ -128,11 +128,11 @@ public class BaseCollectionIdColumnMigrationTest extends AbstractComponentTest {
     addForeignKey(fkName1, fkTable1, "XWI_NAME", table, "XWP_NAME");
     expectModifyIdColumn(table, new XWikiException());
     expect(queryExecMock.executeWriteSQL("alter table " + fkTable1 + " drop foreign key "
-        + fkName1)).andReturn(1).atLeastOnce();
+        + fkName1)).andReturn(1).once();
     // FK has to be readded, even after exception occured
     expect(queryExecMock.executeWriteSQL("alter table " + fkTable1 + " add constraint " + fkName1
         + " foreign key (XWI_ID,XWI_NAME) references " + table + " (XWP_ID,XWP_NAME)")).andReturn(
-            1).atLeastOnce();
+            1).once();
     expectInformationSchemaLoad();
 
     replayDefault();
@@ -191,9 +191,9 @@ public class BaseCollectionIdColumnMigrationTest extends AbstractComponentTest {
     IExpectationSetters<Integer> exp = expect(queryExecMock.executeWriteSQL(getModifyIdColumnSql(
         table, createIdColumnName(table))));
     if (ret instanceof Integer) {
-      exp.andReturn((Integer) ret).atLeastOnce();
+      exp.andReturn((Integer) ret).once();
     } else if (ret instanceof Throwable) {
-      exp.andThrow((Throwable) ret).atLeastOnce();
+      exp.andThrow((Throwable) ret).once();
     }
   }
 

--- a/celements-xwiki-core/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
+++ b/celements-xwiki-core/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
@@ -757,15 +757,11 @@ public abstract class BaseCollection extends BaseElement implements ObjectInterf
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.lang.Object#toString()
-     */
     @Override
-    public String toString()
-    {
-        return toXMLString();
+    public String toString(boolean withDefinition) {
+      String className = getXClassReference() != null ? localEntityReferenceSerializer.serialize(
+          getXClassReference()) : "?";
+      return super.toString(withDefinition) + "_" + className + "_" + getNumber();
     }
 
     /**
@@ -831,4 +827,5 @@ public abstract class BaseCollection extends BaseElement implements ObjectInterf
         // the new document reference.
         this.xClassReferenceCache = null;
     }
+    
 }

--- a/celements-xwiki-core/src/main/java/com/xpn/xwiki/objects/BaseElement.java
+++ b/celements-xwiki-core/src/main/java/com/xpn/xwiki/objects/BaseElement.java
@@ -45,6 +45,25 @@ public abstract class BaseElement implements ElementInterface, Serializable
     private static final Log LOG = LogFactory.getLog(BaseElement.class);
 
     /**
+     * Used to convert a Document Reference to string (compact form without the wiki part if it matches the current
+     * wiki).
+     */
+    protected final EntityReferenceSerializer<String> compactWikiEntityReferenceSerializer =
+        Utils.getComponent(EntityReferenceSerializer.class, "compactwiki");
+
+    /**
+     * Used to convert a proper Document Reference to a string but without the wiki name.
+     */
+    protected final EntityReferenceSerializer<String> localEntityReferenceSerializer =
+        Utils.getComponent(EntityReferenceSerializer.class, "local");
+
+    /**
+     * Used to convert a proper Document Reference to a string but with the wiki name.
+     */
+    protected final EntityReferenceSerializer<String> entityReferenceSerializer =
+        Utils.getComponent(EntityReferenceSerializer.class);
+
+    /**
      * Reference to the document in which this element is defined (for elements where this make sense, for example
      * for an XClass or a XObject).
      */
@@ -57,19 +76,6 @@ public abstract class BaseElement implements ElementInterface, Serializable
     private String name;
 
     private String prettyName;
-
-    /**
-     * Used to convert a Document Reference to string (compact form without the wiki part if it matches the current
-     * wiki).
-     */
-    private EntityReferenceSerializer<String> compactWikiEntityReferenceSerializer =
-        Utils.getComponent(EntityReferenceSerializer.class, "compactwiki");
-
-    /**
-     * Used to convert a proper Document Reference to a string but without the wiki name.
-     */
-    private EntityReferenceSerializer<String> localEntityReferenceSerializer =
-        Utils.getComponent(EntityReferenceSerializer.class, "local");
 
     private long id;
 
@@ -321,4 +327,28 @@ public abstract class BaseElement implements ElementInterface, Serializable
 
         return syntaxId;
     }
+
+    @Override
+    public String toString() {
+      return toString(true);
+    }
+
+    public String toString(boolean withDefinition) {
+      StringBuilder ret = new StringBuilder();
+      if (withDefinition) {
+        ret.append(getClass().getSimpleName()).append(" ");
+        if (hasValidId()) {
+          ret.append(getId()).append(" ");
+        }
+      }
+      if (reference != null) {
+        ret.append(entityReferenceSerializer.serialize(reference));
+      } else if ((name != null) && !name.isEmpty()) {
+        ret.append(name);
+      } else {
+        ret.append("?");
+      }
+      return ret.toString();
+    }
+
 }

--- a/celements-xwiki-core/src/main/java/com/xpn/xwiki/objects/BaseProperty.java
+++ b/celements-xwiki-core/src/main/java/com/xpn/xwiki/objects/BaseProperty.java
@@ -100,6 +100,16 @@ public class BaseProperty extends BaseElement implements PropertyInterface, Seri
       setId(id, IdVersion.CELEMENTS_3);
     }
 
+    @Override
+    public boolean hasValidId() {
+      return getObject() != null ? getObject().hasValidId() : super.hasValidId();
+    }
+
+    @Override
+    public IdVersion getIdVersion() {
+      return getObject() != null ? getObject().getIdVersion() : super.getIdVersion();
+    }
+
     /**
      * {@inheritDoc}
      * 
@@ -193,15 +203,13 @@ public class BaseProperty extends BaseElement implements PropertyInterface, Seri
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see java.lang.Object#toString()
-     */
     @Override
-    public String toString()
-    {
-        return toXMLString();
+    public String toString(boolean withDefinition) {
+      String ret = super.toString(withDefinition);
+      if (getObject() != null) {
+        ret += " " + getObject().toString(false);
+      }
+      return ret;
     }
 
     public Object getCustomMappingValue()

--- a/celements-xwiki-core/src/main/java/com/xpn/xwiki/objects/BaseProperty.java
+++ b/celements-xwiki-core/src/main/java/com/xpn/xwiki/objects/BaseProperty.java
@@ -92,11 +92,7 @@ public class BaseProperty extends BaseElement implements PropertyInterface, Seri
 
     @Override
     public long getId() {
-      if (getObject() != null) {
-        return getObject().getId();
-      } else {
-        throw new IllegalStateException("no base collection set");
-      }
+      return getObject() != null ? getObject().getId() : super.getId();
     }
     
     // needed for properties because access=field not possible (composite id)

--- a/celements-xwiki-core/src/main/java/com/xpn/xwiki/objects/BaseProperty.java
+++ b/celements-xwiki-core/src/main/java/com/xpn/xwiki/objects/BaseProperty.java
@@ -92,8 +92,11 @@ public class BaseProperty extends BaseElement implements PropertyInterface, Seri
 
     @Override
     public long getId() {
-      BaseElement element = getObject() != null ? getObject() : this;
-      return element.getId();
+      if (getObject() != null) {
+        return getObject().getId();
+      } else {
+        throw new IllegalStateException("no base collection set");
+      }
     }
     
     // needed for properties because access=field not possible (composite id)

--- a/celements-xwiki-core/src/test/java/com/xpn/xwiki/objects/BaseElementToStringTest.java
+++ b/celements-xwiki-core/src/test/java/com/xpn/xwiki/objects/BaseElementToStringTest.java
@@ -1,0 +1,76 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+package com.xpn.xwiki.objects;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.xwiki.model.reference.DocumentReference;
+
+import com.celements.store.id.IdVersion;
+import com.xpn.xwiki.test.AbstractBridgedComponentTestCase;
+
+public class BaseElementToStringTest extends AbstractBridgedComponentTestCase {
+
+  private DocumentReference docRef = new DocumentReference("wiki", "Space", "Doc");
+  private DocumentReference classRef = new DocumentReference("wiki", "Celements", "Class");
+
+  @Test
+  public void test_toString_BaseObject() throws Exception {
+    BaseObject obj = new BaseObject();
+    assertEquals("BaseObject ?_?_0", obj.toString());
+    obj.setDocumentReference(docRef);
+    assertEquals("BaseObject wiki:Space.Doc_?_0", obj.toString());
+    obj.setXClassReference(classRef);
+    assertEquals("BaseObject wiki:Space.Doc_Celements.Class_0", obj.toString());
+    obj.setNumber(5);
+    assertEquals("BaseObject wiki:Space.Doc_Celements.Class_5", obj.toString());
+    obj.setId(9876543210L, IdVersion.CELEMENTS_3);
+    assertEquals("BaseObject 9876543210 wiki:Space.Doc_Celements.Class_5", obj.toString());
+    assertEquals("wiki:Space.Doc_Celements.Class_5", obj.toString(false));
+  }
+
+  @Test
+  public void test_toString_BaseProperty() throws Exception {
+    BaseProperty prop = new LongProperty();
+    assertEquals("LongProperty ?", prop.toString());
+    prop.setName("name");
+    assertEquals("LongProperty name", prop.toString());
+    prop.setId(9876543210L, IdVersion.CELEMENTS_3);
+    assertEquals("LongProperty 9876543210 name", prop.toString());
+    assertEquals("name", prop.toString(false));
+  }
+
+  @Test
+  public void test_toString_BaseProperty_withBaseObject() throws Exception {
+    BaseProperty prop = new LongProperty();
+    prop.setName("name");
+    BaseObject obj = new BaseObject();
+    obj.setDocumentReference(docRef);
+    obj.setXClassReference(classRef);
+    obj.setNumber(5);
+    obj.setId(9876543210L, IdVersion.CELEMENTS_3);
+    prop.setObject(obj);
+    assertEquals("LongProperty 9876543210 name wiki:Space.Doc_Celements.Class_5", prop.toString());
+    assertEquals("name wiki:Space.Doc_Celements.Class_5", prop.toString(false));
+  }
+
+}


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-616
- `BaseCollectionIdColumnMigration`: completed xwiki tables list
- fixed `BaseProperty` id-related delegations to the BaseObject
- implemented sensible `toString()` for BaseObject/Property instead of unreadable XML, e.g.: `BaseObject 9876543210 wiki:Space.Doc_Celements.Class_5`
- improve/fix logging for CelHibernateStore (`Object[] args` not properly working)
- added some missing log entries in blocks like:
```
} catch (Exception e) {
  // should *almost* never happen ^^
}
```