### PR TITLE
Move com.celements.mandatory

### DIFF
--- a/celements-model/src/main/java/com/celements/mandatory/AbstractMandatoryDocument.java
+++ b/celements-model/src/main/java/com/celements/mandatory/AbstractMandatoryDocument.java
@@ -19,7 +19,6 @@
  */
 package com.celements.mandatory;
 
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Requirement;
 import org.xwiki.configuration.ConfigurationSource;
@@ -35,7 +34,6 @@ import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.user.api.XWikiUser;
 
-// TODO add unit tests
 public abstract class AbstractMandatoryDocument implements IMandatoryDocumentRole {
 
   @Requirement
@@ -82,7 +80,7 @@ public abstract class AbstractMandatoryDocument implements IMandatoryDocumentRol
   }
 
   private XWikiDocument getDoc() throws XWikiException {
-    XWikiUser originalUser = getContext().getXWikiUser();
+    XWikiUser originalUser = modelContext.getUser();
     try {
       modelContext.setUser(getUser());
       return modelAccess.getOrCreateDocument(getDocRef());
@@ -117,14 +115,14 @@ public abstract class AbstractMandatoryDocument implements IMandatoryDocumentRol
   public abstract Logger getLogger();
 
   protected String getWiki() {
-    return getContext().getDatabase();
+    return modelContext.getWikiRef().getName();
   }
 
   protected XWikiUser getUser() {
-    XWikiUser user = getContext().getXWikiUser();
+    XWikiUser user = modelContext.getUser();
     String defaultUserName = xwikiPropConfigSource.getProperty(
-        "celements.mandatory.defaultGlobalUserName");
-    if (StringUtils.isNotBlank(defaultUserName)) {
+        "celements.mandatory.defaultGlobalUserName", "").trim();
+    if (!defaultUserName.isEmpty()) {
       user = new XWikiUser(defaultUserName, true);
     }
     return user;

--- a/celements-model/src/main/java/com/celements/mandatory/AbstractMandatoryDocument.java
+++ b/celements-model/src/main/java/com/celements/mandatory/AbstractMandatoryDocument.java
@@ -1,0 +1,133 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.celements.mandatory;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Requirement;
+import org.xwiki.configuration.ConfigurationSource;
+import org.xwiki.model.reference.DocumentReference;
+
+import com.celements.model.access.IModelAccessFacade;
+import com.celements.model.access.exception.DocumentLoadException;
+import com.celements.model.access.exception.DocumentSaveException;
+import com.celements.model.context.ModelContext;
+import com.celements.model.util.ModelUtils;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.user.api.XWikiUser;
+
+// TODO add unit tests
+public abstract class AbstractMandatoryDocument implements IMandatoryDocumentRole {
+
+  @Requirement
+  protected IModelAccessFacade modelAccess;
+
+  @Requirement
+  protected ModelContext modelContext;
+
+  @Requirement
+  protected ModelUtils modelUtils;
+
+  @Requirement("xwikiproperties")
+  protected ConfigurationSource xwikiPropConfigSource;
+
+  @Deprecated
+  protected XWikiContext getContext() {
+    return modelContext.getXWikiContext();
+  }
+
+  public abstract String getName();
+
+  @Override
+  public void checkDocuments() throws XWikiException {
+    getLogger().debug("starting mandatory '{}' for db '{}'", getName(), getWiki());
+    if (!skip()) {
+      XWikiDocument doc = getDoc();
+      boolean dirty;
+      if (notMainWiki()) {
+        dirty = checkDocuments(doc);
+      } else {
+        dirty = checkDocumentsMain(doc);
+      }
+      saveDoc(doc, dirty);
+    } else {
+      getLogger().debug("skipping mandatory '{}' for db '{}'", getName(), getWiki());
+    }
+    getLogger().debug("end mandatory '{}' for db '{}'", getName(), getWiki());
+  }
+
+  boolean notMainWiki() {
+    boolean notMainWiki = (getWiki() != null) && !getWiki().equals(getContext().getMainXWiki());
+    getLogger().debug("not main wiki '{}': {}", getWiki(), notMainWiki);
+    return notMainWiki;
+  }
+
+  private XWikiDocument getDoc() throws XWikiException {
+    XWikiUser originalUser = getContext().getXWikiUser();
+    try {
+      modelContext.setUser(getUser());
+      return modelAccess.getOrCreateDocument(getDocRef());
+    } catch (DocumentLoadException dle) {
+      throw new XWikiException(0, 0, "failed to load doc", dle);
+    } finally {
+      modelContext.setUser(originalUser);
+    }
+  }
+
+  protected void saveDoc(XWikiDocument doc, boolean dirty) throws XWikiException {
+    if (dirty) {
+      try {
+        modelAccess.saveDocument(doc, "autocreate mandatory " + getName());
+        getLogger().info("updated doc '{}' for '{}'", doc, getName());
+      } catch (DocumentSaveException exc) {
+        throw new XWikiException(0, 0, "failed to save doc", exc);
+      }
+    } else {
+      getLogger().debug("is uptodate '{}' for '{}'", doc, getName());
+    }
+  }
+
+  protected abstract DocumentReference getDocRef();
+
+  protected abstract boolean skip();
+
+  protected abstract boolean checkDocuments(XWikiDocument doc) throws XWikiException;
+
+  protected abstract boolean checkDocumentsMain(XWikiDocument doc) throws XWikiException;
+
+  public abstract Logger getLogger();
+
+  protected String getWiki() {
+    return getContext().getDatabase();
+  }
+
+  protected XWikiUser getUser() {
+    XWikiUser user = getContext().getXWikiUser();
+    String defaultUserName = xwikiPropConfigSource.getProperty(
+        "celements.mandatory.defaultGlobalUserName");
+    if (StringUtils.isNotBlank(defaultUserName)) {
+      user = new XWikiUser(defaultUserName, true);
+    }
+    return user;
+  }
+
+}

--- a/celements-model/src/main/java/com/celements/mandatory/AbstractMandatoryGroups.java
+++ b/celements-model/src/main/java/com/celements/mandatory/AbstractMandatoryGroups.java
@@ -1,0 +1,91 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.celements.mandatory;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xwiki.component.annotation.Requirement;
+import org.xwiki.model.reference.ClassReference;
+import org.xwiki.model.reference.DocumentReference;
+
+import com.celements.model.access.IModelAccessFacade;
+import com.celements.model.access.exception.DocumentAlreadyExistsException;
+import com.celements.model.access.exception.DocumentSaveException;
+import com.celements.model.context.ModelContext;
+import com.celements.model.object.xwiki.XWikiObjectEditor;
+import com.celements.model.util.ModelUtils;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+
+public abstract class AbstractMandatoryGroups implements IMandatoryDocumentRole {
+
+  @Requirement
+  protected IModelAccessFacade modelAccess;
+
+  @Requirement
+  protected ModelContext modelContext;
+
+  @Requirement
+  protected ModelUtils modelUtils;
+
+  public AbstractMandatoryGroups() {
+    super();
+  }
+
+  @Deprecated
+  protected XWikiContext getContext() {
+    return modelContext.getXWikiContext();
+  }
+
+  @Override
+  public abstract void checkDocuments() throws XWikiException;
+
+  protected abstract String commitName();
+
+  @Override
+  public List<String> dependsOnMandatoryDocuments() {
+    return Collections.emptyList();
+  }
+
+  protected void checkGroup(DocumentReference groupDocRef) throws XWikiException {
+    try {
+      XWikiDocument groupDoc = modelAccess.createDocument(groupDocRef);
+      XWikiObjectEditor.on(groupDoc).filter(getGroupClassRef()).createFirst();
+      modelAccess.saveDocument(groupDoc, "autocreate " + commitName() + " group");
+    } catch (DocumentAlreadyExistsException exc) {
+      getLogger().debug("group doc already exists", exc);
+    } catch (DocumentSaveException exc) {
+      throw new XWikiException(0, 0, "failed to save", exc);
+    }
+  }
+
+  protected ClassReference getGroupClassRef() {
+    return new ClassReference("XWiki", "XWikiGroups");
+  }
+
+  protected Logger getLogger() {
+    return LoggerFactory.getLogger(this.getClass());
+  }
+
+}

--- a/celements-model/src/main/java/com/celements/mandatory/IMandatoryDocumentCompositorRole.java
+++ b/celements-model/src/main/java/com/celements/mandatory/IMandatoryDocumentCompositorRole.java
@@ -1,0 +1,29 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.celements.mandatory;
+
+import org.xwiki.component.annotation.ComponentRole;
+
+@ComponentRole
+public interface IMandatoryDocumentCompositorRole {
+
+  public void checkAllMandatoryDocuments();
+
+}

--- a/celements-model/src/main/java/com/celements/mandatory/IMandatoryDocumentRole.java
+++ b/celements-model/src/main/java/com/celements/mandatory/IMandatoryDocumentRole.java
@@ -1,0 +1,35 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.celements.mandatory;
+
+import java.util.List;
+
+import org.xwiki.component.annotation.ComponentRole;
+
+import com.xpn.xwiki.XWikiException;
+
+@ComponentRole
+public interface IMandatoryDocumentRole {
+
+  public List<String> dependsOnMandatoryDocuments();
+
+  public void checkDocuments() throws XWikiException;
+
+}

--- a/celements-model/src/main/java/com/celements/mandatory/MandatoryDocumentCompositor.java
+++ b/celements-model/src/main/java/com/celements/mandatory/MandatoryDocumentCompositor.java
@@ -1,0 +1,87 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.celements.mandatory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.annotation.Requirement;
+import org.xwiki.context.Execution;
+
+import com.xpn.xwiki.XWikiContext;
+
+@Component
+public class MandatoryDocumentCompositor implements IMandatoryDocumentCompositorRole {
+
+  private static Logger LOGGER = LoggerFactory.getLogger(MandatoryDocumentCompositor.class);
+
+  @Requirement
+  Map<String, IMandatoryDocumentRole> mandatoryDocumentsMap;
+
+  @Requirement
+  Execution execution;
+
+  protected XWikiContext getContext() {
+    return (XWikiContext) execution.getContext().getProperty("xwikicontext");
+  }
+
+  @Override
+  public void checkAllMandatoryDocuments() {
+    LOGGER.info("checkAllMandatoryDocuments for wiki [" + getContext().getDatabase() + "].");
+    for (String mandatoryDocKey : getMandatoryDocumentsList()) {
+      IMandatoryDocumentRole mandatoryDoc = mandatoryDocumentsMap.get(mandatoryDocKey);
+      try {
+        LOGGER.trace("checkDocuments with [" + mandatoryDoc.getClass() + "].");
+        mandatoryDoc.checkDocuments();
+        LOGGER.trace("end checkDocuments with [" + mandatoryDoc.getClass() + "].");
+      } catch (Exception exp) {
+        LOGGER.error("Exception checking mandatory documents for component "
+            + mandatoryDoc.getClass(), exp);
+      }
+    }
+  }
+
+  List<String> getMandatoryDocumentsList() {
+    Collection<String> mandatoryDocElemKeys = new ArrayList<>(mandatoryDocumentsMap.keySet());
+    List<String> mandatoryDocExecList = new Vector<>();
+    do {
+      for (String mandatoryDocElemKey : mandatoryDocElemKeys) {
+        if (mandatoryDocExecList.containsAll(mandatoryDocumentsMap.get(
+            mandatoryDocElemKey).dependsOnMandatoryDocuments())) {
+          mandatoryDocExecList.add(mandatoryDocElemKey);
+        }
+      }
+    } while (mandatoryDocElemKeys.removeAll(mandatoryDocExecList)
+        && !mandatoryDocElemKeys.isEmpty());
+    for (String skippedDocElemKey : mandatoryDocElemKeys) {
+      LOGGER.error("Cannot order all mandatory document roles. Thus skipping: "
+          + skippedDocElemKey);
+    }
+    LOGGER.debug("getMandatoryDocumentsList returning [" + mandatoryDocExecList + "].");
+    return mandatoryDocExecList;
+  }
+
+}

--- a/celements-model/src/main/java/com/celements/mandatory/XWikiRecycleBinIndexes.java
+++ b/celements-model/src/main/java/com/celements/mandatory/XWikiRecycleBinIndexes.java
@@ -1,0 +1,47 @@
+package com.celements.mandatory;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.annotation.Requirement;
+
+import com.celements.model.context.ModelContext;
+import com.celements.query.IQueryExecutionServiceRole;
+import com.xpn.xwiki.XWikiException;
+
+@Component(XWikiRecycleBinIndexes.NAME)
+public class XWikiRecycleBinIndexes implements IMandatoryDocumentRole {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(XWikiRecycleBinIndexes.class);
+
+  public static final String NAME = "celements.mandatory.addIndexToRecycleBin";
+
+  @Requirement
+  IQueryExecutionServiceRole queryExecService;
+
+  @Requirement
+  private ModelContext modelContext;
+
+  @Override
+  public List<String> dependsOnMandatoryDocuments() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void checkDocuments() throws XWikiException {
+    LOGGER.info("executing XWikiRecycleBinIndexes");
+    String prefixAndDb = modelContext.getXWikiContext().getWiki().Param("xwiki.db.prefix")
+        + modelContext.getWikiRef().getName();
+    if (!queryExecService.existsIndex(prefixAndDb, "xwikirecyclebin", "dateIDX")) {
+      queryExecService.executeWriteSQL(getSQLIndexToRecycleBin());
+    }
+  }
+
+  String getSQLIndexToRecycleBin() {
+    return "alter table xwikirecyclebin add index `dateIDX` (XDD_DATE, XDD_ID);";
+  }
+
+}

--- a/celements-model/src/main/resources/META-INF/components.txt
+++ b/celements-model/src/main/resources/META-INF/components.txt
@@ -33,3 +33,5 @@ com.celements.store.CelHibernateStore
 com.celements.web.classes.oldcore.XWikiGlobalRightsClass
 com.celements.store.id.UniqueHashIdComputer
 com.celements.model.migration.BaseCollectionIdColumnMigration
+com.celements.mandatory.MandatoryDocumentCompositor
+com.celements.mandatory.XWikiRecycleBinIndexes


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-653

Moved from [celements-core#158](https://github.com/celements/celements-core/pull/158). Required replacement of `WebUtilsService` in `AbstractMandatoryDocument` with ModelContext/Utils.