### PR TITLE
DocumentSavePreparationCommand

### DIFF
--- a/celements-model/src/main/java/com/celements/store/part/CelHibernateStoreDocumentPart.java
+++ b/celements-model/src/main/java/com/celements/store/part/CelHibernateStoreDocumentPart.java
@@ -219,7 +219,7 @@ public class CelHibernateStoreDocumentPart {
       XWikiContext context) throws XWikiException {
     if (getPrimaryStore(context).exists(doc, context)) {
       XWikiDocument origDoc = getPrimaryStore(context).loadXWikiDoc(doc, context);
-      store.getSession(context).evict(origDoc);
+      store.getSession(context).clear();
       return XWikiObjectFetcher.on(origDoc).filter(new ClassReference(
           obj.getXClassReference())).filter(obj.getNumber()).first();
     } else {

--- a/celements-model/src/main/java/com/celements/store/part/CelHibernateStoreDocumentPart.java
+++ b/celements-model/src/main/java/com/celements/store/part/CelHibernateStoreDocumentPart.java
@@ -61,9 +61,12 @@ public class CelHibernateStoreDocumentPart {
         monitor.startTimer("hibernate");
       }
 
+      XWikiDocument origDoc;
       if (getXObjectFetcher(doc).exists()) {
-        XWikiDocument origDoc = getPrimaryStore(context).loadXWikiDoc(doc, context);
+        origDoc = getPrimaryStore(context).loadXWikiDoc(doc, context);
         store.getSession(context).clear();
+      } else {
+        origDoc = new XWikiDocument(doc.getDocumentReference());
       }
 
       doc.setStore(store);

--- a/celements-model/src/main/java/com/celements/store/part/CelHibernateStoreDocumentPart.java
+++ b/celements-model/src/main/java/com/celements/store/part/CelHibernateStoreDocumentPart.java
@@ -62,7 +62,7 @@ public class CelHibernateStoreDocumentPart {
         monitor.startTimer("hibernate");
       }
 
-      // instantiate before transaction
+      // initialise before beginning store transaction because of possible #loadXWikiDoc
       XObjectPreparer objPreparer = new XObjectPreparer(doc, context);
 
       doc.setStore(store);
@@ -210,14 +210,14 @@ public class CelHibernateStoreDocumentPart {
     }
 
     private XWikiDocument loadOriginalDocument(XWikiContext context) throws XWikiException {
-      XWikiDocument origDoc = new XWikiDocument(cloneRef(doc.getDocumentReference(),
+      XWikiDocument dummyDoc = new XWikiDocument(cloneRef(doc.getDocumentReference(),
           DocumentReference.class));
-      origDoc.setLanguage(doc.getLanguage());
+      dummyDoc.setLanguage(doc.getLanguage());
       if (!doc.isNew() && doc.hasElement(XWikiDocument.HAS_OBJECTS) && getPrimaryStore(
-          context).exists(doc, context)) {
-        origDoc = getPrimaryStore(context).loadXWikiDoc(origDoc, context);
+          context).exists(dummyDoc, context)) {
+        return getPrimaryStore(context).loadXWikiDoc(dummyDoc, context);
       }
-      return origDoc;
+      return dummyDoc;
     }
 
     void execute() throws IdComputationException {
@@ -241,21 +241,6 @@ public class CelHibernateStoreDocumentPart {
       }
     }
 
-  }
-
-  private Optional<BaseObject> fetchExistingObject(XWikiDocument doc, BaseObject obj,
-      XWikiContext context) throws XWikiException {
-    if (getPrimaryStore(context).exists(doc, context)) {
-      XWikiDocument origDoc = new XWikiDocument(cloneRef(doc.getDocumentReference(),
-          DocumentReference.class));
-      origDoc.setLanguage(doc.getLanguage());
-      origDoc = getPrimaryStore(context).loadXWikiDoc(doc, context);
-      store.getSession(context).clear();
-      return XWikiObjectFetcher.on(origDoc).filter(new ClassReference(
-          obj.getXClassReference())).filter(obj.getNumber()).first();
-    } else {
-      return Optional.absent();
-    }
   }
 
   public XWikiDocument loadXWikiDoc(XWikiDocument doc, XWikiContext context) throws XWikiException {

--- a/celements-model/src/main/java/com/celements/store/part/CelHibernateStoreDocumentPart.java
+++ b/celements-model/src/main/java/com/celements/store/part/CelHibernateStoreDocumentPart.java
@@ -64,7 +64,10 @@ public class CelHibernateStoreDocumentPart {
       XWikiDocument origDoc;
       if (getXObjectFetcher(doc).exists()) {
         origDoc = getPrimaryStore(context).loadXWikiDoc(doc, context);
-        store.getSession(context).clear();
+        Session session = store.getSession(context);
+        if (session != null) {
+          session.clear();
+        }
       } else {
         origDoc = new XWikiDocument(doc.getDocumentReference());
       }

--- a/celements-model/src/main/java/com/celements/store/part/CelHibernateStoreDocumentPart.java
+++ b/celements-model/src/main/java/com/celements/store/part/CelHibernateStoreDocumentPart.java
@@ -219,6 +219,7 @@ public class CelHibernateStoreDocumentPart {
       XWikiContext context) throws XWikiException {
     if (getPrimaryStore(context).exists(doc, context)) {
       XWikiDocument origDoc = getPrimaryStore(context).loadXWikiDoc(doc, context);
+      store.getSession(context).evict(origDoc);
       return XWikiObjectFetcher.on(origDoc).filter(new ClassReference(
           obj.getXClassReference())).filter(obj.getNumber()).first();
     } else {

--- a/celements-model/src/main/java/com/celements/store/part/DocumentSavePreparationCommand.java
+++ b/celements-model/src/main/java/com/celements/store/part/DocumentSavePreparationCommand.java
@@ -1,0 +1,132 @@
+package com.celements.store.part;
+
+import static com.celements.model.util.References.*;
+import static com.google.common.base.Preconditions.*;
+
+import java.util.UUID;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.hibernate.FlushMode;
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xwiki.model.reference.ClassReference;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.WikiReference;
+
+import com.celements.model.object.xwiki.XWikiObjectEditor;
+import com.celements.model.object.xwiki.XWikiObjectFetcher;
+import com.celements.store.CelHibernateStore;
+import com.celements.store.id.CelementsIdComputer.IdComputationException;
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.objects.classes.BaseClass;
+import com.xpn.xwiki.store.XWikiStoreInterface;
+
+@Immutable
+class DocumentSavePreparationCommand {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CelHibernateStore.class);
+
+  private final CelHibernateStore store;
+
+  DocumentSavePreparationCommand(CelHibernateStore store) {
+    this.store = checkNotNull(store);
+  }
+
+  Session execute(XWikiDocument doc, boolean bTransaction, XWikiContext context)
+      throws HibernateException, XWikiException, IdComputationException {
+    doc.setStore(store);
+    // Make sure the database name is stored
+    doc.getDocumentReference().setWikiReference(new WikiReference(context.getDatabase()));
+    // Let's update the class XML since this is the new way to store it
+    updateBaseClassXml(doc, context);
+    // These informations will allow to not look for objects and attachments on saving
+    doc.setElement(XWikiDocument.HAS_OBJECTS, XWikiObjectFetcher.on(doc).exists());
+    doc.setElement(XWikiDocument.HAS_ATTACHMENTS, (doc.getAttachmentList().size() != 0));
+    // prepare object ids
+    new XObjectPreparer(doc, context).execute();
+    // begin transaction
+    if (bTransaction) {
+      store.checkHibernate(context);
+      SessionFactory sfactory = store.injectCustomMappingsInSessionFactory(doc, context);
+      store.beginTransaction(sfactory, context);
+    }
+    Session session = store.getSession(context);
+    session.setFlushMode(FlushMode.COMMIT);
+    return session;
+  }
+
+  private void updateBaseClassXml(XWikiDocument doc, XWikiContext context) {
+    BaseClass bclass = doc.getXClass();
+    if (bclass != null) {
+      bclass.setDocumentReference(doc.getDocumentReference());
+      if (bclass.getFieldList().size() > 0) {
+        doc.setXClassXML(bclass.toXMLString());
+      } else {
+        doc.setXClassXML("");
+      }
+      // Store this XWikiClass in the context in case of recursive usage of classes
+      context.addBaseClass(bclass);
+    }
+  }
+
+  private class XObjectPreparer {
+
+    private final XWikiDocument doc;
+    private final XWikiDocument origDoc;
+
+    XObjectPreparer(XWikiDocument doc, XWikiContext context) throws XWikiException {
+      this.doc = doc;
+      this.origDoc = loadOriginalDocument(context);
+    }
+
+    private XWikiDocument loadOriginalDocument(XWikiContext context) throws XWikiException {
+      XWikiDocument dummyDoc = new XWikiDocument(cloneRef(doc.getDocumentReference(),
+          DocumentReference.class));
+      dummyDoc.setLanguage(doc.getLanguage());
+      if (!doc.isNew() && doc.hasElement(XWikiDocument.HAS_OBJECTS) && getPrimaryStore(
+          context).exists(dummyDoc, context)) {
+        return getPrimaryStore(context).loadXWikiDoc(dummyDoc, context);
+      }
+      return dummyDoc;
+    }
+
+    void execute() throws IdComputationException {
+      for (BaseObject obj : XWikiObjectEditor.on(doc).fetch().iter()) {
+        obj.setDocumentReference(doc.getDocumentReference());
+        if (Strings.isNullOrEmpty(obj.getGuid())) {
+          obj.setGuid(UUID.randomUUID().toString());
+        }
+        if (!obj.hasValidId()) {
+          Optional<BaseObject> existingObj = XWikiObjectFetcher.on(origDoc).filter(
+              new ClassReference(obj.getXClassReference())).filter(obj.getNumber()).first();
+          if (existingObj.isPresent() && existingObj.get().hasValidId()) {
+            obj.setId(existingObj.get().getId(), existingObj.get().getIdVersion());
+            LOGGER.debug("saveXWikiDoc - obj [{}] already existed, keeping id", obj);
+          } else {
+            long nextId = store.getIdComputer().computeNextObjectId(doc);
+            obj.setId(nextId, store.getIdComputer().getIdVersion());
+            LOGGER.debug("saveXWikiDoc - obj [{}] is new, computed new id", obj);
+          }
+        }
+      }
+    }
+
+  }
+
+  /**
+   * @return the cache store if one is configured, else it's self referencing
+   */
+  private XWikiStoreInterface getPrimaryStore(XWikiContext context) {
+    return context.getWiki().getStore();
+  }
+
+}

--- a/celements-model/src/test/java/com/celements/store/CelHibernateStoreTest.java
+++ b/celements-model/src/test/java/com/celements/store/CelHibernateStoreTest.java
@@ -42,7 +42,6 @@ public class CelHibernateStoreTest extends AbstractComponentTest {
     expect(getWikiMock().hasBacklinks(getContext())).andReturn(false).anyTimes();
     expect(getWikiMock().Param(eq("xwiki.store.hibernate.useclasstables.read"), eq("1"))).andReturn(
         "0").anyTimes();
-
   }
 
   @Test

--- a/celements-model/src/test/java/com/celements/store/CelHibernateStoreTest.java
+++ b/celements-model/src/test/java/com/celements/store/CelHibernateStoreTest.java
@@ -76,6 +76,7 @@ public class CelHibernateStoreTest extends AbstractComponentTest {
     Session sessionMock = createSessionMock(doc);
     expectSaveDocExists(sessionMock, false);
     expect(sessionMock.save(capture(docCapture))).andReturn(null).once();
+    expect(sessionMock.close()).andReturn(null);
 
     replayDefault();
     getStore(sessionMock).saveXWikiDoc(doc, getContext());

--- a/celements-model/src/test/java/com/celements/store/part/DocumentSavePreparationCommandOrderTest.java
+++ b/celements-model/src/test/java/com/celements/store/part/DocumentSavePreparationCommandOrderTest.java
@@ -1,0 +1,82 @@
+package com.celements.store.part;
+
+import static com.celements.common.test.CelementsTestUtils.*;
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+import org.hibernate.FlushMode;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.xwiki.model.reference.DocumentReference;
+
+import com.celements.common.test.AbstractComponentTest;
+import com.celements.store.CelHibernateStore;
+import com.celements.store.id.CelementsIdComputer;
+import com.celements.store.id.UniqueHashIdComputer;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.web.Utils;
+
+public class DocumentSavePreparationCommandOrderTest extends AbstractComponentTest {
+
+  private DocumentSavePreparationCommand savePrepCmd;
+
+  private CelHibernateStore storeStrictMock;
+  private Session sessionMock;
+
+  @Before
+  public void prepareTest() throws Exception {
+    storeStrictMock = createStrictMock(CelHibernateStore.class);
+    getDefaultMocks().add(storeStrictMock);
+    expect(getWikiMock().getStore()).andReturn(storeStrictMock).anyTimes();
+    sessionMock = createMockAndAddToDefault(Session.class);
+    sessionMock.setFlushMode(FlushMode.COMMIT);
+    expectLastCall().anyTimes();
+    savePrepCmd = new DocumentSavePreparationCommand(storeStrictMock);
+  }
+
+  @Test
+  public void test_execute_order() throws Exception {
+    XWikiDocument doc = createDoc(false, null);
+    BaseObject obj = addObject(doc);
+
+    expect(storeStrictMock.exists(anyObject(XWikiDocument.class), same(getContext()))).andReturn(
+        true);
+    expect(storeStrictMock.loadXWikiDoc(anyObject(XWikiDocument.class), same(
+        getContext()))).andReturn(createDoc(false, null));
+    expect(storeStrictMock.getIdComputer()).andReturn(Utils.getComponent(CelementsIdComputer.class,
+        UniqueHashIdComputer.NAME)).anyTimes();
+    storeStrictMock.checkHibernate(same(getContext()));
+    expectLastCall();
+    SessionFactory sfactoryMock = createMockAndAddToDefault(SessionFactory.class);
+    expect(storeStrictMock.injectCustomMappingsInSessionFactory(same(doc), same(
+        getContext()))).andReturn(sfactoryMock);
+    expect(storeStrictMock.beginTransaction(same(sfactoryMock), same(getContext()))).andReturn(
+        true);
+    expect(storeStrictMock.getSession(getContext())).andReturn(sessionMock);
+
+    replayDefault();
+    Session ret = savePrepCmd.execute(doc, true, getContext());
+    verifyDefault();
+    assertSame(sessionMock, ret);
+  }
+
+  private BaseObject addObject(XWikiDocument doc) {
+    BaseObject obj = new BaseObject();
+    obj.setXClassReference(new DocumentReference("xwikidb", "space", "class"));
+    obj.setGuid("");
+    doc.addXObject(obj);
+    return obj;
+  }
+
+  private XWikiDocument createDoc(boolean isNew, String language) {
+    DocumentReference docRef = new DocumentReference("xwikidb", "space", "doc");
+    XWikiDocument doc = new XWikiDocument(docRef);
+    doc.setLanguage(language);
+    doc.setNew(isNew);
+    return doc;
+  }
+
+}

--- a/celements-model/src/test/java/com/celements/store/part/DocumentSavePreparationCommandTest.java
+++ b/celements-model/src/test/java/com/celements/store/part/DocumentSavePreparationCommandTest.java
@@ -1,0 +1,193 @@
+package com.celements.store.part;
+
+import static com.celements.common.test.CelementsTestUtils.*;
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+
+import org.easymock.Capture;
+import org.hibernate.FlushMode;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.xwiki.model.reference.DocumentReference;
+
+import com.celements.common.test.AbstractComponentTest;
+import com.celements.common.test.ExceptionAsserter;
+import com.celements.store.CelHibernateStore;
+import com.celements.store.id.CelementsIdComputer;
+import com.celements.store.id.IdVersion;
+import com.celements.store.id.UniqueHashIdComputer;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiAttachment;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.web.Utils;
+
+public class DocumentSavePreparationCommandTest extends AbstractComponentTest {
+
+  private DocumentSavePreparationCommand savePrepCmd;
+
+  private CelHibernateStore storeMock;
+  private Session sessionMock;
+
+  @Before
+  public void prepareTest() throws Exception {
+    storeMock = createMockAndAddToDefault(CelHibernateStore.class);
+    expect(getWikiMock().getStore()).andReturn(storeMock).anyTimes();
+    expect(storeMock.getIdComputer()).andReturn(Utils.getComponent(CelementsIdComputer.class,
+        UniqueHashIdComputer.NAME)).anyTimes();
+    sessionMock = createMockAndAddToDefault(Session.class);
+    sessionMock.setFlushMode(FlushMode.COMMIT);
+    expectLastCall().anyTimes();
+    expect(storeMock.getSession(getContext())).andReturn(sessionMock).anyTimes();
+    savePrepCmd = new DocumentSavePreparationCommand(storeMock);
+  }
+
+  @Test
+  public void test_execute() throws Exception {
+    XWikiDocument doc = createDoc(false, null);
+
+    replayDefault();
+    Session ret = savePrepCmd.execute(doc, false, getContext());
+    verifyDefault();
+    assertSame(sessionMock, ret);
+    assertSame("store should be set", storeMock, doc.getStore());
+    assertEquals("doc should be set to context db", getContext().getDatabase(),
+        doc.getDocumentReference().getWikiReference().getName());
+    assertFalse(doc.hasElement(XWikiDocument.HAS_OBJECTS));
+    assertFalse(doc.hasElement(XWikiDocument.HAS_ATTACHMENTS));
+  }
+
+  @Test
+  public void test_execute_transaction() throws Exception {
+    XWikiDocument doc = createDoc(false, null);
+
+    storeMock.checkHibernate(same(getContext()));
+    expectLastCall();
+    SessionFactory sfactoryMock = createMockAndAddToDefault(SessionFactory.class);
+    expect(storeMock.injectCustomMappingsInSessionFactory(same(doc), same(getContext()))).andReturn(
+        sfactoryMock);
+    expect(storeMock.beginTransaction(same(sfactoryMock), same(getContext()))).andReturn(true);
+
+    replayDefault();
+    Session ret = savePrepCmd.execute(doc, true, getContext());
+    verifyDefault();
+    assertSame(sessionMock, ret);
+  }
+
+  @Test
+  public void test_execute_object() throws Exception {
+    XWikiDocument doc = createDoc(true, null);
+    BaseObject obj = addObject(doc);
+
+    assertTrue(obj.getGuid().isEmpty());
+    assertEquals(0, obj.getId());
+    replayDefault();
+    savePrepCmd.execute(doc, false, getContext());
+    verifyDefault();
+    assertTrue(doc.hasElement(XWikiDocument.HAS_OBJECTS));
+    assertFalse(obj.getGuid().isEmpty());
+    assertEquals(-974136870929809407L, obj.getId());
+  }
+
+  @Test
+  public void test_execute_object_load() throws Exception {
+    XWikiDocument doc = createDoc(false, "ch");
+    BaseObject obj = addObject(doc);
+    XWikiDocument origDoc = createDoc(false, "ch");
+    BaseObject origObj = addObject(origDoc);
+    origObj.setId(1234, IdVersion.CELEMENTS_3);
+    Capture<XWikiDocument> docCaptureExists = new Capture<>();
+    Capture<XWikiDocument> docCaptureLoad = new Capture<>();
+    expect(storeMock.exists(capture(docCaptureExists), same(getContext()))).andReturn(true);
+    expect(storeMock.loadXWikiDoc(capture(docCaptureLoad), same(getContext()))).andReturn(origDoc);
+
+    replayDefault();
+    savePrepCmd.execute(doc, false, getContext());
+    verifyDefault();
+    assertDocCapture(doc, docCaptureExists);
+    assertDocCapture(doc, docCaptureLoad);
+    assertEquals(origObj.getId(), obj.getId());
+  }
+
+  private void assertDocCapture(XWikiDocument doc, Capture<XWikiDocument> docCapture) {
+    assertNotSame(doc, docCapture.getValue());
+    assertEquals(doc.getDocumentReference(), docCapture.getValue().getDocumentReference());
+    assertEquals(doc.getLanguage(), docCapture.getValue().getLanguage());
+  }
+
+  @Test
+  public void test_execute_object_load_noObj() throws Exception {
+    XWikiDocument doc = createDoc(false, null);
+    BaseObject obj = addObject(doc);
+    expect(storeMock.exists(anyObject(XWikiDocument.class), same(getContext()))).andReturn(true);
+    expect(storeMock.loadXWikiDoc(anyObject(XWikiDocument.class), same(getContext()))).andReturn(
+        createDoc(false, null));
+
+    replayDefault();
+    savePrepCmd.execute(doc, false, getContext());
+    verifyDefault();
+    assertEquals(-974136870929809407L, obj.getId());
+  }
+
+  @Test
+  public void test_execute_object_load_notExists() throws Exception {
+    XWikiDocument doc = createDoc(false, null);
+    BaseObject obj = addObject(doc);
+    expect(storeMock.exists(anyObject(XWikiDocument.class), same(getContext()))).andReturn(false);
+
+    replayDefault();
+    savePrepCmd.execute(doc, false, getContext());
+    verifyDefault();
+    assertEquals(-974136870929809407L, obj.getId());
+  }
+
+  @Test
+  public void test_execute_object_load_XWE() throws Exception {
+    final XWikiDocument doc = createDoc(false, null);
+    addObject(doc);
+    XWikiException cause = new XWikiException();
+    expect(storeMock.exists(anyObject(XWikiDocument.class), same(getContext()))).andThrow(cause);
+
+    replayDefault();
+    new ExceptionAsserter<XWikiException>(XWikiException.class, cause) {
+
+      @Override
+      protected void execute() throws Exception {
+        savePrepCmd.execute(doc, false, getContext());
+      }
+    }.evaluate();
+    verifyDefault();
+  }
+
+  private BaseObject addObject(XWikiDocument doc) {
+    BaseObject obj = new BaseObject();
+    obj.setXClassReference(new DocumentReference("xwikidb", "space", "class"));
+    obj.setGuid("");
+    doc.addXObject(obj);
+    return obj;
+  }
+
+  @Test
+  public void test_execute_attachment() throws Exception {
+    XWikiDocument doc = createDoc(false, null);
+    doc.setAttachmentList(Arrays.asList(new XWikiAttachment(doc, "file")));
+
+    replayDefault();
+    savePrepCmd.execute(doc, false, getContext());
+    verifyDefault();
+    assertTrue(doc.hasElement(XWikiDocument.HAS_ATTACHMENTS));
+  }
+
+  private XWikiDocument createDoc(boolean isNew, String language) {
+    DocumentReference docRef = new DocumentReference("xwikidb", "space", "doc");
+    XWikiDocument doc = new XWikiDocument(docRef);
+    doc.setLanguage(language);
+    doc.setNew(isNew);
+    return doc;
+  }
+
+}


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-682

Introduction of `DocumentSavePreparationCommand` moves the `loadXWikiDoc` call before the store transaction start and thus avoids the `HibernateException`.