### PR TITLE
CELDEV-783 Releases and XWikiDocument clone fix

### DIFF
--- a/celements-model/pom.xml
+++ b/celements-model/pom.xml
@@ -28,7 +28,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>celements-model</artifactId>
-  <version>3.13</version>
+  <version>3.14-SNAPSHOT</version>
   <description>Celements XWiki</description>
   <dependencies>
     <!-- Add here all your dependencies -->
@@ -49,6 +49,6 @@
     <connection>scm:git:git@github.com:celements/celements-xwiki.git</connection>
     <developerConnection>scm:git:git@github.com:celements/celements-xwiki.git</developerConnection>
     <url>https://github.com/celements/celements-xwiki</url>
-    <tag>celements-model-3.13</tag>
+    <tag>HEAD</tag>
   </scm>
 </project>

--- a/celements-model/pom.xml
+++ b/celements-model/pom.xml
@@ -28,7 +28,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>celements-model</artifactId>
-  <version>3.13-SNAPSHOT</version>
+  <version>3.13</version>
   <description>Celements XWiki</description>
   <dependencies>
     <!-- Add here all your dependencies -->
@@ -49,6 +49,6 @@
     <connection>scm:git:git@github.com:celements/celements-xwiki.git</connection>
     <developerConnection>scm:git:git@github.com:celements/celements-xwiki.git</developerConnection>
     <url>https://github.com/celements/celements-xwiki</url>
-    <tag>HEAD</tag>
+    <tag>celements-model-3.13</tag>
   </scm>
 </project>

--- a/celements-xwiki-core/pom.xml
+++ b/celements-xwiki-core/pom.xml
@@ -28,7 +28,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>celements-xwiki-core</artifactId>
-  <version>3.6</version>
+  <version>3.7-SNAPSHOT</version>
   <description>Celements XWiki</description>
   <dependencies>
     <!-- Add here all your dependencies -->
@@ -315,7 +315,7 @@
     <connection>scm:git:git@github.com:celements/celements-xwiki.git</connection>
     <developerConnection>scm:git:git@github.com:celements/celements-xwiki.git</developerConnection>
     <url>https://github.com/celements/celements-xwiki</url>
-    <tag>celements-xwiki-core-3.6</tag>
+    <tag>HEAD</tag>
   </scm>
    <build>
     <pluginManagement>

--- a/celements-xwiki-core/pom.xml
+++ b/celements-xwiki-core/pom.xml
@@ -28,7 +28,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>celements-xwiki-core</artifactId>
-  <version>3.6-SNAPSHOT</version>
+  <version>3.6</version>
   <description>Celements XWiki</description>
   <dependencies>
     <!-- Add here all your dependencies -->
@@ -315,7 +315,7 @@
     <connection>scm:git:git@github.com:celements/celements-xwiki.git</connection>
     <developerConnection>scm:git:git@github.com:celements/celements-xwiki.git</developerConnection>
     <url>https://github.com/celements/celements-xwiki</url>
-    <tag>HEAD</tag>
+    <tag>celements-xwiki-core-3.6</tag>
   </scm>
    <build>
     <pluginManagement>

--- a/celements-xwiki-core/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/celements-xwiki-core/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -3256,8 +3256,8 @@ public class XWikiDocument implements DocumentModelBridge
      */
     private void clone(XWikiDocument document) throws XWikiException
     {
-        setId(document.getId());
         setDocumentReference(document.getDocumentReference());
+        setId(document.getId());
         setRCSVersion(document.getRCSVersion());
         setDocumentArchive(document.getDocumentArchive());
         setAuthor(document.getAuthor());
@@ -3292,10 +3292,10 @@ public class XWikiDocument implements DocumentModelBridge
 
         cloneXObjects(document);
         cloneAttachments(document);
-        
+
         setContentDirty(document.isContentDirty());
         setMetaDataDirty(document.isMetaDataDirty());
-        
+
         this.elements = document.elements;
 
         this.originalDocument = document.originalDocument;
@@ -3321,9 +3321,11 @@ public class XWikiDocument implements DocumentModelBridge
     {
         XWikiDocument doc = null;
         try {
-            Constructor constructor = getClass().getConstructor(DocumentReference.class);
-            doc = (XWikiDocument) constructor.newInstance(newDocumentReference);
+            Constructor<? extends XWikiDocument> constructor = getClass().getConstructor(
+                DocumentReference.class);
+            doc = constructor.newInstance(newDocumentReference);
 
+            doc.setId(getId());
             // use version field instead of getRCSVersion because it returns "1.1" if version==null.
             doc.version = this.version;
             doc.setDocumentArchive(getDocumentArchive());
@@ -3339,7 +3341,6 @@ public class XWikiDocument implements DocumentModelBridge
             doc.setFormat(getFormat());
             doc.setFromCache(isFromCache());
             doc.setElements(getElements());
-            doc.setId(getId());
             doc.setMeta(getMeta());
             doc.setMetaDataDirty(isMetaDataDirty());
             doc.setMostRecent(isMostRecent());
@@ -3354,26 +3355,30 @@ public class XWikiDocument implements DocumentModelBridge
             doc.setLanguage(getLanguage());
             doc.setTranslation(getTranslation());
             doc.setXClass((BaseClass) getXClass().clone());
-            doc.setXClassXML(getXClassXML());
             doc.setComment(getComment());
             doc.setMinorEdit(isMinorEdit());
             doc.setSyntax(getSyntax());
             doc.setHidden(isHidden());
 
             if (keepsIdentity) {
+                doc.setXClassXML(getXClassXML());
                 doc.cloneXObjects(this);
                 doc.cloneAttachments(this);
             } else {
+                doc.getXClass().setCustomMapping(null);
                 doc.duplicateXObjects(this);
                 doc.copyAttachments(this);
             }
 
+            doc.setContentDirty(isContentDirty());
+            doc.setMetaDataDirty(isMetaDataDirty());
+
             doc.elements = this.elements;
 
             doc.originalDocument = this.originalDocument;
-        } catch (Exception e) {
+        } catch (ReflectiveOperationException exc) {
             // This should not happen
-            LOG.error("Exception while cloning document", e);
+            LOG.error("Exception while cloning document", exc);
         }
         return doc;
     }

--- a/celements-xwiki-core/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/celements-xwiki-core/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -3332,7 +3332,6 @@ public class XWikiDocument implements DocumentModelBridge
             doc.setAuthor(getAuthor());
             doc.setContentAuthor(getContentAuthor());
             doc.setContent(getContent());
-            doc.setContentDirty(isContentDirty());
             doc.setCreationDate(getCreationDate());
             doc.setDate(getDate());
             doc.setCustomClass(getCustomClass());
@@ -3342,7 +3341,6 @@ public class XWikiDocument implements DocumentModelBridge
             doc.setFromCache(isFromCache());
             doc.setElements(getElements());
             doc.setMeta(getMeta());
-            doc.setMetaDataDirty(isMetaDataDirty());
             doc.setMostRecent(isMostRecent());
             doc.setNew(isNew());
             doc.setStore(getStore());

--- a/celements-xwiki-core/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/celements-xwiki-core/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -3256,13 +3256,13 @@ public class XWikiDocument implements DocumentModelBridge
      */
     private void clone(XWikiDocument document) throws XWikiException
     {
+        setId(document.getId());
         setDocumentReference(document.getDocumentReference());
         setRCSVersion(document.getRCSVersion());
         setDocumentArchive(document.getDocumentArchive());
         setAuthor(document.getAuthor());
         setContentAuthor(document.getContentAuthor());
         setContent(document.getContent());
-        setContentDirty(document.isContentDirty());
         setCreationDate(document.getCreationDate());
         setDate(document.getDate());
         setCustomClass(document.getCustomClass());
@@ -3271,9 +3271,7 @@ public class XWikiDocument implements DocumentModelBridge
         setFormat(document.getFormat());
         setFromCache(document.isFromCache());
         setElements(document.getElements());
-        setId(document.getId());
         setMeta(document.getMeta());
-        setMetaDataDirty(document.isMetaDataDirty());
         setMostRecent(document.isMostRecent());
         setNew(document.isNew());
         setStore(document.getStore());
@@ -3294,6 +3292,10 @@ public class XWikiDocument implements DocumentModelBridge
 
         cloneXObjects(document);
         cloneAttachments(document);
+        
+        setContentDirty(document.isContentDirty());
+        setMetaDataDirty(document.isMetaDataDirty());
+        
         this.elements = document.elements;
 
         this.originalDocument = document.originalDocument;


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-783

- fix `XWikiDocument#clone` for content/metaData dirty
- release celements-model 3.13
- release celements-xwiki-core 3.6