### PR TITLE
CELDEV-803 Move User into Model Context and refactorings

### DIFF
--- a/celements-model/src/main/java/com/celements/auth/user/User.java
+++ b/celements-model/src/main/java/com/celements/auth/user/User.java
@@ -6,6 +6,7 @@ import javax.validation.constraints.NotNull;
 import org.xwiki.component.annotation.ComponentRole;
 import org.xwiki.model.reference.DocumentReference;
 
+import com.celements.web.classes.oldcore.XWikiUsersClass.Type;
 import com.google.common.base.Optional;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.user.api.XWikiUser;
@@ -41,6 +42,9 @@ public interface User {
 
   @NotNull
   Optional<String> getAdminLanguage();
+
+  @NotNull
+  Type getType();
 
   boolean isActive();
 

--- a/celements-model/src/main/java/com/celements/auth/user/User.java
+++ b/celements-model/src/main/java/com/celements/auth/user/User.java
@@ -1,0 +1,47 @@
+package com.celements.auth.user;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import javax.validation.constraints.NotNull;
+
+import org.xwiki.component.annotation.ComponentRole;
+import org.xwiki.model.reference.DocumentReference;
+
+import com.google.common.base.Optional;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.user.api.XWikiUser;
+
+@NotThreadSafe
+@ComponentRole
+public interface User {
+
+  public void initialize(@NotNull DocumentReference userDocRef) throws UserInstantiationException;
+
+  @NotNull
+  DocumentReference getDocRef();
+
+  @NotNull
+  XWikiDocument getDocument();
+
+  boolean isGlobal();
+
+  @NotNull
+  XWikiUser asXWikiUser();
+
+  @NotNull
+  Optional<String> getEmail();
+
+  @NotNull
+  Optional<String> getFirstName();
+
+  @NotNull
+  Optional<String> getLastName();
+
+  @NotNull
+  Optional<String> getPrettyName();
+
+  @NotNull
+  Optional<String> getAdminLanguage();
+
+  boolean isActive();
+
+}

--- a/celements-model/src/main/java/com/celements/auth/user/UserCreateException.java
+++ b/celements-model/src/main/java/com/celements/auth/user/UserCreateException.java
@@ -1,0 +1,19 @@
+package com.celements.auth.user;
+
+public class UserCreateException extends Exception {
+
+  private static final long serialVersionUID = -6637742987473484753L;
+
+  public UserCreateException(String message) {
+    super(message);
+  }
+
+  public UserCreateException(Exception exc) {
+    super(exc);
+  }
+
+  public UserCreateException(String message, Exception exc) {
+    super(message, exc);
+  }
+
+}

--- a/celements-model/src/main/java/com/celements/auth/user/UserInstantiationException.java
+++ b/celements-model/src/main/java/com/celements/auth/user/UserInstantiationException.java
@@ -1,0 +1,19 @@
+package com.celements.auth.user;
+
+public class UserInstantiationException extends Exception {
+
+  private static final long serialVersionUID = -5349680105776140376L;
+
+  public UserInstantiationException(String message) {
+    super(message);
+  }
+
+  public UserInstantiationException(Exception exc) {
+    super(exc);
+  }
+
+  public UserInstantiationException(String message, Exception exc) {
+    super(message, exc);
+  }
+
+}

--- a/celements-model/src/main/java/com/celements/auth/user/UserService.java
+++ b/celements-model/src/main/java/com/celements/auth/user/UserService.java
@@ -1,0 +1,114 @@
+package com.celements.auth.user;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
+import org.xwiki.component.annotation.ComponentRole;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.SpaceReference;
+import org.xwiki.model.reference.WikiReference;
+
+import com.google.common.base.Optional;
+
+@ComponentRole
+public interface UserService {
+
+  public static final String DEFAULT_LOGIN_FIELD = "loginname";
+
+  /**
+   * @return the default user space reference for the current wiki
+   */
+  @NotNull
+  SpaceReference getUserSpaceRef();
+
+  /**
+   * @param wikiRef
+   * @return the default user space reference for the given wikiRef
+   */
+  @NotNull
+  SpaceReference getUserSpaceRef(@Nullable WikiReference wikiRef);
+
+  /**
+   * @param accountName
+   * @return the resolved user doc reference, enforces the user space from
+   *         {@link #getUserSpaceRef()}
+   */
+  @NotNull
+  DocumentReference resolveUserDocRef(@NotNull String accountName);
+
+  /**
+   * @param userDocRef
+   * @return a {@link User} instance for the given user doc
+   * @throws UserInstantiationException
+   *           if the given user doc is invalid
+   */
+  @NotNull
+  User getUser(@NotNull DocumentReference userDocRef) throws UserInstantiationException;
+
+  /**
+   * @return list of user fields for which one can login, e.g. 'name', 'email' or 'validkey'
+   */
+  @NotNull
+  Set<String> getPossibleLoginFields();
+
+  /**
+   * creates a new user with the provided userData. generates a random name if given accountName is
+   * already taken.
+   *
+   * @param accountName
+   * @param userData
+   * @param validate
+   *          sends a validation mail if true
+   * @return the new {@link User} instance
+   * @throws UserCreateException
+   *           if the user creation process failed
+   */
+  @NotNull
+  User createNewUser(@NotNull String accountName, @NotNull Map<String, String> userData,
+      boolean validate) throws UserCreateException;
+
+  /**
+   * creates a new user with the provided userData. generates a random name if no account name is
+   * provided.
+   *
+   * @param userData
+   * @param validate
+   *          sends a validation mail if true
+   * @return the new {@link User} instance
+   * @throws UserCreateException
+   *           if the user creation process failed
+   */
+  @NotNull
+  User createNewUser(@NotNull Map<String, String> userData, boolean validate)
+      throws UserCreateException;
+
+  /**
+   * looks up the user by the given login value with {@link #getPossibleLoginFields()}
+   *
+   * @param login
+   *          the login value
+   * @return the matched {@link User} instance or absent if the given login doesn't match or isn't
+   *         unique
+   */
+  @NotNull
+  Optional<User> getUserForLoginField(@NotNull String login);
+
+  /**
+   * looks up the user by the given login value with the possible login fields.
+   *
+   * @param login
+   *          the login value
+   * @param possibleLoginFields
+   *          list of user fields for which one can login, e.g. 'name', 'email' or 'validkey'
+   * @return the matched {@link User} instance or absent if the given login doesn't match or isn't
+   *         unique
+   */
+  @NotNull
+  Optional<User> getUserForLoginField(@NotNull String login,
+      @Nullable Collection<String> possibleLoginFields);
+
+}

--- a/celements-model/src/main/java/com/celements/model/classes/fields/list/AbstractListField.java
+++ b/celements-model/src/main/java/com/celements/model/classes/fields/list/AbstractListField.java
@@ -106,7 +106,7 @@ public abstract class AbstractListField<T, E> extends AbstractClassField<T> impl
         LOGGER.warn("unable to resolve value '{}' for '{}'", obj, this);
       }
     }
-    return iter.transform(marshaller.getResolver());
+    return iter.transform(marshaller.getResolver()).filter(Predicates.notNull());
   }
 
   public Marshaller<E> getMarshaller() {

--- a/celements-model/src/main/java/com/celements/model/context/DefaultModelContext.java
+++ b/celements-model/src/main/java/com/celements/model/context/DefaultModelContext.java
@@ -4,8 +4,6 @@ import static com.google.common.base.Preconditions.*;
 
 import java.net.URL;
 
-import javax.annotation.Nullable;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.component.annotation.Component;
@@ -19,6 +17,9 @@ import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.SpaceReference;
 import org.xwiki.model.reference.WikiReference;
 
+import com.celements.auth.user.User;
+import com.celements.auth.user.UserInstantiationException;
+import com.celements.auth.user.UserService;
 import com.celements.configuration.CelementsFromWikiConfigurationSource;
 import com.celements.model.access.IModelAccessFacade;
 import com.celements.model.access.exception.DocumentNotExistsException;
@@ -106,22 +107,62 @@ public class DefaultModelContext implements ModelContext {
   }
 
   @Override
+  @Deprecated
   public XWikiUser getUser() {
     return getXWikiContext().getXWikiUser();
   }
 
   @Override
-  public XWikiUser setUser(@Nullable XWikiUser user) {
+  public Optional<User> getCurrentUser() {
+    User user = null;
+    Optional<DocumentReference> userDocRef = getCurrentUserDocRef();
+    if (userDocRef.isPresent()) {
+      try {
+        user = getUserService().getUser(userDocRef.get());
+      } catch (UserInstantiationException exc) {
+        LOGGER.warn("failed loading user '{}'", userDocRef.get(), exc);
+      }
+    }
+    return Optional.fromNullable(user);
+  }
+
+  private Optional<DocumentReference> getCurrentUserDocRef() {
+    DocumentReference userDocRef = null;
+    XWikiUser xUser = getXWikiContext().getXWikiUser();
+    if ((xUser != null) && !Strings.isNullOrEmpty(xUser.getUser())) {
+      userDocRef = getUserService().resolveUserDocRef(xUser.getUser());
+    }
+    return Optional.fromNullable(userDocRef);
+  }
+
+  @Override
+  @Deprecated
+  public XWikiUser setUser(XWikiUser xUser) {
     XWikiUser oldUser = getUser();
-    if (user != null) {
-      getXWikiContext().setUser(user.getUser(), user.isMain());
+    if (xUser != null) {
+      setCurrentXUser(xUser);
     } else {
-      getXWikiContext().setUser(null);
+      clearCurrentUser();
     }
     return oldUser;
   }
 
   @Override
+  public void setCurrentUser(User user) {
+    setCurrentXUser(checkNotNull(user).asXWikiUser());
+  }
+
+  private void setCurrentXUser(XWikiUser xUser) {
+    getXWikiContext().setUser(xUser.getUser(), xUser.isMain());
+  }
+
+  @Override
+  public void clearCurrentUser() {
+    getXWikiContext().setUser(null);
+  }
+
+  @Override
+  @Deprecated
   public String getUserName() {
     return getXWikiContext().getUser();
   }
@@ -225,6 +266,10 @@ public class DefaultModelContext implements ModelContext {
 
   private IModelAccessFacade getModelAccess() {
     return Utils.getComponent(IModelAccessFacade.class);
+  }
+
+  private UserService getUserService() {
+    return Utils.getComponent(UserService.class);
   }
 
 }

--- a/celements-model/src/main/java/com/celements/model/context/DefaultModelContext.java
+++ b/celements-model/src/main/java/com/celements/model/context/DefaultModelContext.java
@@ -28,6 +28,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.user.api.XWikiRightService;
 import com.xpn.xwiki.user.api.XWikiUser;
 import com.xpn.xwiki.web.Utils;
 import com.xpn.xwiki.web.XWikiRequest;
@@ -141,7 +142,7 @@ public class DefaultModelContext implements ModelContext {
   @Override
   public Optional<User> getCurrentUser() {
     XWikiUser xUser = getXWikiContext().getXWikiUser();
-    if ((xUser != null) && !Strings.isNullOrEmpty(xUser.getUser())) {
+    if (isValidUser(xUser)) {
       DocumentReference userDocRef = getUserService().resolveUserDocRef(xUser.getUser());
       try {
         return Optional.of(getUserService().getUser(userDocRef));
@@ -150,6 +151,11 @@ public class DefaultModelContext implements ModelContext {
       }
     }
     return Optional.absent();
+  }
+
+  private boolean isValidUser(XWikiUser xUser) {
+    return (xUser != null) && !Strings.isNullOrEmpty(xUser.getUser()) && !xUser.getUser().equals(
+        XWikiRightService.GUEST_USER_FULLNAME);
   }
 
   @Override

--- a/celements-model/src/main/java/com/celements/model/context/DefaultModelContext.java
+++ b/celements-model/src/main/java/com/celements/model/context/DefaultModelContext.java
@@ -97,12 +97,34 @@ public class DefaultModelContext implements ModelContext {
   @Override
   @Deprecated
   public XWikiDocument getDoc() {
-    return getXWikiContext().getDoc();
+    return getDocInternal();
   }
 
   @Override
   public Optional<XWikiDocument> getCurrentDoc() {
-    return Optional.fromNullable(getXWikiContext().getDoc());
+    return Optional.fromNullable(getDocInternal());
+  }
+
+  @Override
+  public Optional<DocumentReference> getCurrentDocRef() {
+    DocumentReference currentDocRef = null;
+    if (getDocInternal() != null) {
+      currentDocRef = getDocInternal().getDocumentReference();
+    }
+    return Optional.fromNullable(currentDocRef);
+  }
+
+  @Override
+  public Optional<SpaceReference> getCurrentSpaceRef() {
+    SpaceReference currentSpaceRef = null;
+    if (getDocInternal() != null) {
+      currentSpaceRef = getDocInternal().getDocumentReference().getLastSpaceReference();
+    }
+    return Optional.fromNullable(currentSpaceRef);
+  }
+
+  private XWikiDocument getDocInternal() {
+    return getXWikiContext().getDoc();
   }
 
   @Override

--- a/celements-model/src/main/java/com/celements/model/context/DefaultModelContext.java
+++ b/celements-model/src/main/java/com/celements/model/context/DefaultModelContext.java
@@ -95,13 +95,19 @@ public class DefaultModelContext implements ModelContext {
   }
 
   @Override
+  @Deprecated
   public XWikiDocument getDoc() {
     return getXWikiContext().getDoc();
   }
 
   @Override
+  public Optional<XWikiDocument> getCurrentDoc() {
+    return Optional.fromNullable(getXWikiContext().getDoc());
+  }
+
+  @Override
   public XWikiDocument setDoc(XWikiDocument doc) {
-    XWikiDocument oldDoc = getDoc();
+    XWikiDocument oldDoc = getCurrentDoc().orNull();
     getXWikiContext().setDoc(doc);
     return oldDoc;
   }
@@ -216,7 +222,7 @@ public class DefaultModelContext implements ModelContext {
 
   private String getDefaultLangFromConfigSrc(EntityReference ref) {
     WikiReference wikiBefore = getWikiRef();
-    XWikiDocument docBefore = getDoc();
+    XWikiDocument docBefore = getCurrentDoc().orNull();
     try {
       ConfigurationSource configSrc;
       setWikiRef(getModelUtils().extractRef(ref, WikiReference.class).or(getWikiRef()));

--- a/celements-model/src/main/java/com/celements/model/context/ModelContext.java
+++ b/celements-model/src/main/java/com/celements/model/context/ModelContext.java
@@ -9,6 +9,7 @@ import org.xwiki.component.annotation.ComponentRole;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.WikiReference;
 
+import com.celements.auth.user.User;
 import com.celements.model.util.ModelUtils;
 import com.google.common.base.Optional;
 import com.xpn.xwiki.XWikiContext;
@@ -73,13 +74,32 @@ public interface ModelContext {
   @Nullable
   XWikiDocument setDoc(@Nullable XWikiDocument doc);
 
+  /**
+   * @deprecated instead use {@link #getCurrentUser()}
+   */
   @Nullable
+  @Deprecated
   XWikiUser getUser();
 
+  @NotNull
+  Optional<User> getCurrentUser();
+
+  /**
+   * @deprecated instead use {@link #setCurrentUser(User)} or {@link #clearCurrentUser()}
+   */
   @Nullable
+  @Deprecated
   XWikiUser setUser(@Nullable XWikiUser user);
 
+  void setCurrentUser(@NotNull User user);
+
+  void clearCurrentUser();
+
+  /**
+   * @deprecated instead use {@link #getUserDocRef()}
+   */
   @NotNull
+  @Deprecated
   String getUserName();
 
   @NotNull

--- a/celements-model/src/main/java/com/celements/model/context/ModelContext.java
+++ b/celements-model/src/main/java/com/celements/model/context/ModelContext.java
@@ -61,10 +61,17 @@ public interface ModelContext {
   WikiReference getMainWikiRef();
 
   /**
-   * @return the current doc set in context
+   * @deprecated instead use {@link #getCurrentDoc}
    */
+  @Deprecated
   @Nullable
   XWikiDocument getDoc();
+
+  /**
+   * @return the current doc set in context
+   */
+  @NotNull
+  Optional<XWikiDocument> getCurrentDoc();
 
   /**
    * @param doc
@@ -77,8 +84,8 @@ public interface ModelContext {
   /**
    * @deprecated instead use {@link #getCurrentUser()}
    */
-  @Nullable
   @Deprecated
+  @Nullable
   XWikiUser getUser();
 
   @NotNull
@@ -87,8 +94,8 @@ public interface ModelContext {
   /**
    * @deprecated instead use {@link #setCurrentUser(User)} or {@link #clearCurrentUser()}
    */
-  @Nullable
   @Deprecated
+  @Nullable
   XWikiUser setUser(@Nullable XWikiUser user);
 
   void setCurrentUser(@NotNull User user);

--- a/celements-model/src/main/java/com/celements/model/context/ModelContext.java
+++ b/celements-model/src/main/java/com/celements/model/context/ModelContext.java
@@ -6,7 +6,9 @@ import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
 import org.xwiki.component.annotation.ComponentRole;
+import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.SpaceReference;
 import org.xwiki.model.reference.WikiReference;
 
 import com.celements.auth.user.User;
@@ -72,6 +74,18 @@ public interface ModelContext {
    */
   @NotNull
   Optional<XWikiDocument> getCurrentDoc();
+
+  /**
+   * @return the current doc reference set in context
+   */
+  @NotNull
+  Optional<DocumentReference> getCurrentDocRef();
+
+  /**
+   * @return the current space set in context
+   */
+  @NotNull
+  Optional<SpaceReference> getCurrentSpaceRef();
 
   /**
    * @param doc

--- a/celements-model/src/main/java/com/celements/model/context/ModelContext.java
+++ b/celements-model/src/main/java/com/celements/model/context/ModelContext.java
@@ -112,9 +112,7 @@ public interface ModelContext {
   @Nullable
   XWikiUser setUser(@Nullable XWikiUser user);
 
-  void setCurrentUser(@NotNull User user);
-
-  void clearCurrentUser();
+  void setCurrentUser(@Nullable User user);
 
   /**
    * @deprecated instead use {@link #getUserDocRef()}

--- a/celements-model/src/main/java/com/celements/rights/access/DefaultRightsAccessFacade.java
+++ b/celements-model/src/main/java/com/celements/rights/access/DefaultRightsAccessFacade.java
@@ -136,15 +136,15 @@ public class DefaultRightsAccessFacade implements IRightsAccessFacadeRole {
   }
 
   @Override
-  public boolean isAdminUser() {
-    return isAdminUser(context.getCurrentUser().orNull());
+  public boolean isAdmin() {
+    return isAdmin(context.getCurrentUser().orNull());
   }
 
   @Override
-  public boolean isAdminUser(User user) {
+  public boolean isAdmin(User user) {
     boolean ret = (user != null) && (hasAdminRightsOnPreferences(user) || isInGroup(
         getAdminGroupDocRef(), user));
-    LOGGER.debug("isAdminUser: [{}] for user [{}]", ret, user);
+    LOGGER.debug("isAdmin: [{}] for user [{}]", ret, user);
     return ret;
   }
 
@@ -170,20 +170,20 @@ public class DefaultRightsAccessFacade implements IRightsAccessFacadeRole {
 
   @Override
   public boolean isAdvancedAdmin(User user) {
-    boolean ret = isAdminUser(user) && (user.isGlobal() || (user.getType() == Type.Advanced));
+    boolean ret = isAdmin(user) && (user.isGlobal() || (user.getType() == Type.Advanced));
     LOGGER.debug("isAdvancedAdmin: [{}] for user [{}]", ret, user);
     return ret;
   }
 
   @Override
-  public boolean isSuperAdminUser() {
-    return isSuperAdminUser(context.getCurrentUser().orNull());
+  public boolean isSuperAdmin() {
+    return isSuperAdmin(context.getCurrentUser().orNull());
   }
 
   @Override
-  public boolean isSuperAdminUser(User user) {
-    boolean ret = isAdminUser(user) && user.isGlobal();
-    LOGGER.debug("isSuperAdminUser: [{}] for user [{}]", ret, user);
+  public boolean isSuperAdmin(User user) {
+    boolean ret = isAdmin(user) && user.isGlobal();
+    LOGGER.debug("isSuperAdmin: [{}] for user [{}]", ret, user);
     return ret;
   }
 

--- a/celements-model/src/main/java/com/celements/rights/access/DefaultRightsAccessFacade.java
+++ b/celements-model/src/main/java/com/celements/rights/access/DefaultRightsAccessFacade.java
@@ -107,7 +107,7 @@ public class DefaultRightsAccessFacade implements IRightsAccessFacadeRole {
     try {
       String accountName = XWikiRightService.GUEST_USER_FULLNAME;
       if (userDocRef != null) {
-        accountName = modelUtils.serializeRefLocal(userDocRef);
+        accountName = modelUtils.serializeRef(userDocRef);
       }
       return getRightsService().hasAccessLevel(level, accountName, fullName, getContext());
     } catch (XWikiException xwe) {

--- a/celements-model/src/main/java/com/celements/rights/access/DefaultRightsAccessFacade.java
+++ b/celements-model/src/main/java/com/celements/rights/access/DefaultRightsAccessFacade.java
@@ -8,12 +8,16 @@ import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
 
+import com.celements.auth.user.User;
 import com.celements.model.context.ModelContext;
+import com.celements.model.reference.RefBuilder;
 import com.celements.model.util.ModelUtils;
 import com.celements.rights.access.internal.IEntityReferenceRandomCompleterRole;
+import com.celements.web.classes.oldcore.XWikiUsersClass.Type;
 import com.google.common.base.Optional;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.user.api.XWikiGroupService;
 import com.xpn.xwiki.user.api.XWikiRightService;
 import com.xpn.xwiki.user.api.XWikiUser;
 
@@ -29,19 +33,27 @@ public class DefaultRightsAccessFacade implements IRightsAccessFacadeRole {
   private ModelUtils modelUtils;
 
   @Requirement
-  private ModelContext modelContext;
+  private ModelContext context;
 
   /**
-   * @deprecated instead use {@link #modelContext}
+   * @deprecated instead use {@link #context}
    */
   @Deprecated
   private XWikiContext getContext() {
-    return modelContext.getXWikiContext();
+    return context.getXWikiContext();
   }
 
   @Override
   public XWikiRightService getRightsService() {
     return getContext().getWiki().getRightService();
+  }
+
+  private XWikiGroupService getGroupService() {
+    try {
+      return getContext().getWiki().getGroupService(getContext());
+    } catch (XWikiException xwe) {
+      throw new IllegalStateException("failed getting GroupService", xwe);
+    }
   }
 
   @Override
@@ -56,11 +68,16 @@ public class DefaultRightsAccessFacade implements IRightsAccessFacadeRole {
 
   @Override
   public boolean hasAccessLevel(EntityReference ref, EAccessLevel level) {
-    return hasAccessLevel(ref, level, getContext().getXWikiUser());
+    return hasAccessLevel(ref, level, context.getCurrentUser().orNull());
   }
 
   @Override
   public boolean hasAccessLevel(EntityReference ref, EAccessLevel level, XWikiUser user) {
+    return hasAccessLevel(ref, level, user); // TODO get user
+  }
+
+  @Override
+  public boolean hasAccessLevel(EntityReference ref, EAccessLevel level, User user) {
     boolean ret = false;
     DocumentReference docRef = null;
     EntityReference entityRef = randomCompleter.randomCompleteSpaceRef(ref);
@@ -70,24 +87,114 @@ public class DefaultRightsAccessFacade implements IRightsAccessFacadeRole {
       docRef = ((AttachmentReference) entityRef).getDocumentReference();
     }
     if ((docRef != null) && (level != null)) {
-      try {
-        String userName = (user != null ? user.getUser() : XWikiRightService.GUEST_USER_FULLNAME);
-        ret = getRightsService().hasAccessLevel(level.getIdentifier(), userName,
-            modelUtils.serializeRef(docRef), getContext());
-      } catch (XWikiException xwe) {
-        // already being catched in XWikiRightServiceImpl.hasAccessLevel()
-        LOGGER.error("should not happen", xwe);
+      String accountName = XWikiRightService.GUEST_USER_FULLNAME;
+      if (user != null) {
+        accountName = modelUtils.serializeRef(user.getDocRef());
       }
+      ret = hasAccessLevelInternal(level.getIdentifier(), accountName, modelUtils.serializeRef(
+          docRef));
     }
     LOGGER.debug("hasAccessLevel: for ref '{}', level '{}' and user '{}' returned '{}'", ref, level,
         user, ret);
     return ret;
   }
 
+  private boolean hasAccessLevelInternal(String level, String accountName, String fullName) {
+    try {
+      return getRightsService().hasAccessLevel(level, accountName, fullName, getContext());
+    } catch (XWikiException xwe) {
+      // already being catched in XWikiRightServiceImpl.hasAccessLevel()
+      LOGGER.error("should not happen", xwe);
+      return false;
+    }
+  }
+
+  @Override
+  public boolean isInGroup(DocumentReference groupDocRef, User user) {
+    try {
+      return (user != null) && getGroupService().getAllGroupsReferencesForMember(user.getDocRef(),
+          0, 0, getContext()).contains(groupDocRef);
+    } catch (XWikiException xwe) {
+      LOGGER.warn("isInGroup: failed for user [{}], group [{}]", user, groupDocRef, xwe);
+      return false;
+    }
+  }
+
   @Override
   public boolean isLoggedIn() {
-    boolean ret = !XWikiRightService.GUEST_USER_FULLNAME.equals(getContext().getUser());
+    boolean ret = context.getCurrentUser().isPresent();
     LOGGER.info("isLoggedIn: {}", ret);
     return ret;
   }
+
+  @Override
+  public boolean isAdminUser() {
+    return isAdminUser(context.getCurrentUser().orNull());
+  }
+
+  @Override
+  public boolean isAdminUser(User user) {
+    boolean ret = (user != null) && (hasAdminRightsOnPreferences(user) || isInGroup(
+        getAdminGroupDocRef(), user));
+    LOGGER.debug("isAdminUser: [{}] for user [{}]", ret, user);
+    return ret;
+  }
+
+  private DocumentReference getAdminGroupDocRef() {
+    return new RefBuilder().doc("XWikiAdminGroup").space("XWiki").with(context.getWikiRef()).build(
+        DocumentReference.class);
+  }
+
+  private boolean hasAdminRightsOnPreferences(User user) {
+    boolean ret = false;
+    String accountName = modelUtils.serializeRef(user.getDocRef());
+    ret = hasAccessLevelInternal("admin", accountName, "XWiki.XWikiPreferences");
+    if (!ret && context.getCurrentDoc().isPresent()) {
+      String spacePrefFullName = context.getCurrentSpaceRef().get().getName() + ".WebPreferences";
+      ret = hasAccessLevelInternal("admin", accountName, spacePrefFullName);
+    }
+    return ret;
+  }
+
+  @Override
+  public boolean isAdvancedAdmin() {
+    return isAdvancedAdmin(context.getCurrentUser().orNull());
+  }
+
+  @Override
+  public boolean isAdvancedAdmin(User user) {
+    boolean ret = isAdminUser(user) && (user.isGlobal() || (user.getType() == Type.Advanced));
+    LOGGER.debug("isAdvancedAdmin: [{}] for user [{}]", ret, user);
+    return ret;
+  }
+
+  @Override
+  public boolean isSuperAdminUser() {
+    return isSuperAdminUser(context.getCurrentUser().orNull());
+  }
+
+  @Override
+  public boolean isSuperAdminUser(User user) {
+    boolean ret = isAdminUser(user) && user.isGlobal();
+    LOGGER.debug("isSuperAdminUser: [{}] for user [{}]", ret, user);
+    return ret;
+  }
+
+  @Override
+  public boolean isLayoutEditor() {
+    return isLayoutEditor(context.getCurrentUser().orNull());
+  }
+
+  @Override
+  public boolean isLayoutEditor(User user) {
+    boolean ret = isAdvancedAdmin(user) || isInGroup(getLayoutEditorsGroupDocRef(), user);
+    LOGGER.debug("isLayoutEditor: [{}] for user [{}]", ret, user);
+    return ret;
+  }
+
+  private DocumentReference getLayoutEditorsGroupDocRef() {
+    return new RefBuilder().doc("LayoutEditorsGroup").space("XWiki").with(
+        context.getWikiRef()).build(DocumentReference.class);
+  }
+
 }

--- a/celements-model/src/main/java/com/celements/rights/access/DefaultRightsAccessFacade.java
+++ b/celements-model/src/main/java/com/celements/rights/access/DefaultRightsAccessFacade.java
@@ -72,6 +72,7 @@ public class DefaultRightsAccessFacade implements IRightsAccessFacadeRole {
   }
 
   @Override
+  @Deprecated
   public boolean hasAccessLevel(EntityReference ref, EAccessLevel level, XWikiUser xUser) {
     return hasAccessLevel(ref, level, (xUser != null) ? modelUtils.resolveRef(xUser.getUser(),
         DocumentReference.class) : null);

--- a/celements-model/src/main/java/com/celements/rights/access/IRightsAccessFacadeRole.java
+++ b/celements-model/src/main/java/com/celements/rights/access/IRightsAccessFacadeRole.java
@@ -1,26 +1,52 @@
 package com.celements.rights.access;
 
 import org.xwiki.component.annotation.ComponentRole;
+import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
 
+import com.celements.auth.user.User;
 import com.xpn.xwiki.user.api.XWikiRightService;
 import com.xpn.xwiki.user.api.XWikiUser;
 
 @ComponentRole
-public interface IRightsAccessFacadeRole {
+interface IRightsAccessFacadeRole {
 
   /**
-   * instead use hasAccessLevel(EntityReference, EAccessLevel, XWikiUser)
+   * instead use hasAccessLevel(EntityReference, EAccessLevel, User)
    */
   @Deprecated
-  public boolean hasAccessLevel(String right, XWikiUser user, EntityReference entityRef);
+  boolean hasAccessLevel(String right, XWikiUser user, EntityReference entityRef);
 
-  public XWikiRightService getRightsService();
+  XWikiRightService getRightsService();
 
-  public boolean hasAccessLevel(EntityReference ref, EAccessLevel level);
+  boolean hasAccessLevel(EntityReference ref, EAccessLevel level);
 
-  public boolean hasAccessLevel(EntityReference ref, EAccessLevel level, XWikiUser user);
+  boolean hasAccessLevel(EntityReference ref, EAccessLevel level, User user);
 
-  public boolean isLoggedIn();
+  /**
+   * instead use hasAccessLevel(EntityReference, EAccessLevel, User)
+   */
+  @Deprecated
+  boolean hasAccessLevel(EntityReference ref, EAccessLevel level, XWikiUser user);
+
+  boolean isInGroup(DocumentReference groupDocRef, User user);
+
+  boolean isLoggedIn();
+
+  boolean isAdminUser();
+
+  boolean isAdminUser(User user);
+
+  boolean isAdvancedAdmin();
+
+  boolean isAdvancedAdmin(User user);
+
+  boolean isSuperAdminUser();
+
+  boolean isSuperAdminUser(User user);
+
+  boolean isLayoutEditor();
+
+  boolean isLayoutEditor(User user);
 
 }

--- a/celements-model/src/main/java/com/celements/rights/access/IRightsAccessFacadeRole.java
+++ b/celements-model/src/main/java/com/celements/rights/access/IRightsAccessFacadeRole.java
@@ -27,7 +27,7 @@ public interface IRightsAccessFacadeRole {
    * instead use hasAccessLevel(EntityReference, EAccessLevel, User)
    */
   @Deprecated
-  boolean hasAccessLevel(EntityReference ref, EAccessLevel level, XWikiUser user);
+  boolean hasAccessLevel(EntityReference ref, EAccessLevel level, XWikiUser xUser);
 
   boolean isInGroup(DocumentReference groupDocRef, User user);
 

--- a/celements-model/src/main/java/com/celements/rights/access/IRightsAccessFacadeRole.java
+++ b/celements-model/src/main/java/com/celements/rights/access/IRightsAccessFacadeRole.java
@@ -9,7 +9,7 @@ import com.xpn.xwiki.user.api.XWikiRightService;
 import com.xpn.xwiki.user.api.XWikiUser;
 
 @ComponentRole
-interface IRightsAccessFacadeRole {
+public interface IRightsAccessFacadeRole {
 
   /**
    * instead use hasAccessLevel(EntityReference, EAccessLevel, User)

--- a/celements-model/src/main/java/com/celements/rights/access/IRightsAccessFacadeRole.java
+++ b/celements-model/src/main/java/com/celements/rights/access/IRightsAccessFacadeRole.java
@@ -33,17 +33,17 @@ public interface IRightsAccessFacadeRole {
 
   boolean isLoggedIn();
 
-  boolean isAdminUser();
+  boolean isAdmin();
 
-  boolean isAdminUser(User user);
+  boolean isAdmin(User user);
 
   boolean isAdvancedAdmin();
 
   boolean isAdvancedAdmin(User user);
 
-  boolean isSuperAdminUser();
+  boolean isSuperAdmin();
 
-  boolean isSuperAdminUser(User user);
+  boolean isSuperAdmin(User user);
 
   boolean isLayoutEditor();
 

--- a/celements-model/src/main/java/com/celements/rights/access/RightsAccessScriptService.java
+++ b/celements-model/src/main/java/com/celements/rights/access/RightsAccessScriptService.java
@@ -59,4 +59,20 @@ public class RightsAccessScriptService implements ScriptService {
   public boolean isLoggedIn() {
     return rightsAccess.isLoggedIn();
   }
+
+  public boolean isAdminUser() {
+    return rightsAccess.isAdminUser();
+  }
+
+  public boolean isAdvancedAdmin() {
+    return rightsAccess.isAdvancedAdmin();
+  }
+
+  public boolean isSuperAdminUser() {
+    return rightsAccess.isSuperAdminUser();
+  }
+
+  public boolean isLayoutEditor() {
+    return rightsAccess.isLayoutEditor();
+  }
 }

--- a/celements-model/src/main/java/com/celements/rights/access/RightsAccessScriptService.java
+++ b/celements-model/src/main/java/com/celements/rights/access/RightsAccessScriptService.java
@@ -60,16 +60,16 @@ public class RightsAccessScriptService implements ScriptService {
     return rightsAccess.isLoggedIn();
   }
 
-  public boolean isAdminUser() {
-    return rightsAccess.isAdminUser();
+  public boolean isAdmin() {
+    return rightsAccess.isAdmin();
   }
 
   public boolean isAdvancedAdmin() {
     return rightsAccess.isAdvancedAdmin();
   }
 
-  public boolean isSuperAdminUser() {
-    return rightsAccess.isSuperAdminUser();
+  public boolean isSuperAdmin() {
+    return rightsAccess.isSuperAdmin();
   }
 
   public boolean isLayoutEditor() {

--- a/celements-model/src/main/java/com/celements/web/classes/oldcore/XWikiUsersClass.java
+++ b/celements-model/src/main/java/com/celements/web/classes/oldcore/XWikiUsersClass.java
@@ -8,10 +8,15 @@ import com.celements.model.classes.AbstractClassDefinition;
 import com.celements.model.classes.fields.BooleanField;
 import com.celements.model.classes.fields.ClassField;
 import com.celements.model.classes.fields.StringField;
+import com.celements.model.classes.fields.list.single.EnumSingleListField;
 
 @Singleton
 @Component(XWikiUsersClass.CLASS_DEF_HINT)
 public class XWikiUsersClass extends AbstractClassDefinition implements IOldCoreClassDef {
+
+  public enum Type {
+    Simple, Advanced;
+  }
 
   public static final String CLASS_NAME = "XWikiUsers";
   public static final String CLASS_FN = CLASS_SPACE + "." + CLASS_NAME;
@@ -35,6 +40,9 @@ public class XWikiUsersClass extends AbstractClassDefinition implements IOldCore
   public static final ClassField<Boolean> FIELD_ACTIVE = new BooleanField.Builder(CLASS_FN,
       "active").prettyName("Active").displayType("active").build();
 
+  public static final ClassField<Type> FIELD_TYPE = new EnumSingleListField.Builder<>(CLASS_FN,
+      "usertype", Type.class).prettyName("User type").build();
+
   // XXX class is incomplete, extend if needed:
   // addTextField("default_language", "Default Language", 30);
   // addTextField("company", "Company", 30);
@@ -44,7 +52,6 @@ public class XWikiUsersClass extends AbstractClassDefinition implements IOldCore
   // addStaticListField("imtype", "IM Type", "---|AIM|Yahoo|Jabber|MSN|Skype|ICQ");
   // addTextField("imaccount", "imaccount", 30);
   // addStaticListField("editor", "Default Editor", "---|Text|Wysiwyg");
-  // addStaticListField("usertype", "User type", "Simple|Advanced");
   // addBooleanField("accessibility", "Enable extra accessibility features", "yesno");
   // addTextField("skin", "skin", 30);
   // addStaticListField("pageWidth", "Preferred page width", "default|640|800|1024|1280|1600");

--- a/celements-model/src/test/java/com/celements/rights/access/DefaultRightsAccessFacadeTest.java
+++ b/celements-model/src/test/java/com/celements/rights/access/DefaultRightsAccessFacadeTest.java
@@ -220,7 +220,7 @@ public class DefaultRightsAccessFacadeTest extends AbstractComponentTest {
     DocumentReference docRef = new DocumentReference(context.getDatabase(), "MySpace",
         "MyDocument");
     EAccessLevel level = EAccessLevel.VIEW;
-    XWikiUser user = new XWikiUser("MySpace.MyUser");
+    XWikiUser user = new XWikiUser(modelUtils.serializeRef(docRef));
     expect(expectRightsServiceMock().hasAccessLevel(eq(level.getIdentifier()), eq(user.getUser()),
         eq(modelUtils.serializeRef(docRef)), same(context))).andReturn(false);
 
@@ -434,6 +434,7 @@ public class DefaultRightsAccessFacadeTest extends AbstractComponentTest {
 
   private void expectHasAdminRights(String accountName, boolean hasAdminXWikiPref,
       Boolean hasAdminWebPref) throws XWikiException {
+    accountName = getContext().getDatabase() + ":" + accountName;
     XWikiRightService rightsServiceMock = expectRightsServiceMock();
     expect(rightsServiceMock.hasAccessLevel(eq("admin"), eq(accountName), eq(
         "XWiki.XWikiPreferences"), same(context))).andReturn(hasAdminXWikiPref);

--- a/celements-model/src/test/java/com/celements/rights/access/DefaultRightsAccessFacadeTest.java
+++ b/celements-model/src/test/java/com/celements/rights/access/DefaultRightsAccessFacadeTest.java
@@ -291,7 +291,7 @@ public class DefaultRightsAccessFacadeTest extends AbstractComponentTest {
   }
 
   @Test
-  public void test_isAdminUser_false() throws Exception {
+  public void test_isAdmin_false() throws Exception {
     String accountName = "XWiki.XWikiTest";
     User user = expectUser(accountName);
     expectHasAdminRights(accountName, false, null);
@@ -300,12 +300,12 @@ public class DefaultRightsAccessFacadeTest extends AbstractComponentTest {
             Collections.<DocumentReference>emptyList());
 
     replayDefault();
-    assertFalse(rightsAccess.isAdminUser(user));
+    assertFalse(rightsAccess.isAdmin(user));
     verifyDefault();
   }
 
   @Test
-  public void test_isAdminUser_false_withContextDoc() throws Exception {
+  public void test_isAdmin_false_withContextDoc() throws Exception {
     String accountName = "XWiki.XWikiTest";
     User user = expectUser(accountName);
     expectHasAdminRights(accountName, false, false);
@@ -315,35 +315,35 @@ public class DefaultRightsAccessFacadeTest extends AbstractComponentTest {
     context.setDoc(new XWikiDocument(new DocumentReference("xwikidb", "MySpace", "MyDoc")));
 
     replayDefault();
-    assertFalse(rightsAccess.isAdminUser(user));
+    assertFalse(rightsAccess.isAdmin(user));
     verifyDefault();
   }
 
   @Test
-  public void test_isAdminUser_adminRights_xwikiPref() throws Exception {
+  public void test_isAdmin_adminRights_xwikiPref() throws Exception {
     String accountName = "XWiki.XWikiTest";
     User user = expectUser(accountName);
     expectHasAdminRights(accountName, true, null);
 
     replayDefault();
-    assertTrue(rightsAccess.isAdminUser(user));
+    assertTrue(rightsAccess.isAdmin(user));
     verifyDefault();
   }
 
   @Test
-  public void test_isAdminUser_adminRights_webPref() throws Exception {
+  public void test_isAdmin_adminRights_webPref() throws Exception {
     String accountName = "XWiki.XWikiTest";
     User user = expectUser(accountName);
     expectHasAdminRights(accountName, false, true);
     context.setDoc(new XWikiDocument(new DocumentReference("xwikidb", "MySpace", "MyDoc")));
 
     replayDefault();
-    assertTrue(rightsAccess.isAdminUser(user));
+    assertTrue(rightsAccess.isAdmin(user));
     verifyDefault();
   }
 
   @Test
-  public void test_isAdminUser_inAdminGroup() throws Exception {
+  public void test_isAdmin_inAdminGroup() throws Exception {
     String accountName = "XWiki.XWikiTest";
     User user = expectUser(accountName);
     expectHasAdminRights(accountName, false, null);
@@ -352,36 +352,36 @@ public class DefaultRightsAccessFacadeTest extends AbstractComponentTest {
             rightsAccess.getAdminGroupDocRef()));
 
     replayDefault();
-    assertTrue(rightsAccess.isAdminUser(user));
+    assertTrue(rightsAccess.isAdmin(user));
     verifyDefault();
   }
 
   @Test
-  public void test_isSuperAdminUser() throws Exception {
+  public void test_isSuperAdmin() throws Exception {
     String accountName = "XWiki.XWikiTest";
     User user = expectUser(accountName);
     expect(user.isGlobal()).andReturn(true);
     expectHasAdminRights(accountName, true, null);
 
     replayDefault();
-    assertTrue(rightsAccess.isSuperAdminUser(user));
+    assertTrue(rightsAccess.isSuperAdmin(user));
     verifyDefault();
   }
 
   @Test
-  public void test_isSuperAdminUser_false_notGlobal() throws Exception {
+  public void test_isSuperAdmin_false_notGlobal() throws Exception {
     String accountName = "XWiki.XWikiTest";
     User user = expectUser(accountName);
     expect(user.isGlobal()).andReturn(false);
     expectHasAdminRights(accountName, true, null);
 
     replayDefault();
-    assertFalse(rightsAccess.isSuperAdminUser(user));
+    assertFalse(rightsAccess.isSuperAdmin(user));
     verifyDefault();
   }
 
   @Test
-  public void test_isSuperAdminUser_false_notAdmin() throws Exception {
+  public void test_isSuperAdmin_false_notAdmin() throws Exception {
     String accountName = "XWiki.XWikiTest";
     User user = expectUser(accountName);
     expectHasAdminRights(accountName, false, null);
@@ -390,7 +390,7 @@ public class DefaultRightsAccessFacadeTest extends AbstractComponentTest {
             Collections.<DocumentReference>emptyList());
 
     replayDefault();
-    assertFalse(rightsAccess.isSuperAdminUser(user));
+    assertFalse(rightsAccess.isSuperAdmin(user));
     verifyDefault();
   }
 

--- a/celements-model/src/test/java/com/celements/rights/access/DefaultRightsAccessFacade_SpaceTest.java
+++ b/celements-model/src/test/java/com/celements/rights/access/DefaultRightsAccessFacade_SpaceTest.java
@@ -1,5 +1,6 @@
 package com.celements.rights.access;
 
+import static com.celements.common.test.CelementsTestUtils.*;
 import static org.easymock.EasyMock.*;
 import static org.junit.Assert.*;
 
@@ -14,7 +15,7 @@ import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.SpaceReference;
 import org.xwiki.model.reference.WikiReference;
 
-import com.celements.common.test.AbstractBridgedComponentTestCase;
+import com.celements.common.test.AbstractComponentTest;
 import com.celements.model.util.ModelUtils;
 import com.celements.rights.access.internal.IEntityReferenceRandomCompleterRole;
 import com.xpn.xwiki.XWiki;
@@ -28,7 +29,7 @@ import com.xpn.xwiki.user.api.XWikiUser;
 import com.xpn.xwiki.user.impl.xwiki.XWikiRightServiceImpl;
 import com.xpn.xwiki.web.Utils;
 
-public class DefaultRightsAccessFacade_SpaceTest extends AbstractBridgedComponentTestCase {
+public class DefaultRightsAccessFacade_SpaceTest extends AbstractComponentTest {
 
   private XWiki xwiki;
   private XWikiContext context;
@@ -38,7 +39,7 @@ public class DefaultRightsAccessFacade_SpaceTest extends AbstractBridgedComponen
   private IEntityReferenceRandomCompleterRole randomCompleterMock;
 
   @Before
-  public void setUp_DefaultRightsAccessFacadeTest() throws Exception {
+  public void prepareTest() throws Exception {
     randomCompleterMock = registerComponentMock(IEntityReferenceRandomCompleterRole.class);
     context = getContext();
     xwiki = getWikiMock();

--- a/celements-model/src/test/java/com/celements/rights/access/EntityReferenceRandomCompleterTest.java
+++ b/celements-model/src/test/java/com/celements/rights/access/EntityReferenceRandomCompleterTest.java
@@ -1,5 +1,6 @@
 package com.celements.rights.access;
 
+import static com.celements.common.test.CelementsTestUtils.*;
 import static junit.framework.Assert.*;
 import static org.easymock.EasyMock.*;
 
@@ -12,20 +13,20 @@ import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.SpaceReference;
 import org.xwiki.model.reference.WikiReference;
 
-import com.celements.common.test.AbstractBridgedComponentTestCase;
+import com.celements.common.test.AbstractComponentTest;
 import com.celements.rights.access.internal.EntityReferenceRandomCompleter;
 import com.celements.rights.access.internal.IEntityReferenceRandomCompleterRole;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.web.Utils;
 
-public class EntityReferenceRandomCompleterTest extends AbstractBridgedComponentTestCase {
+public class EntityReferenceRandomCompleterTest extends AbstractComponentTest {
 
   private EntityReferenceRandomCompleter randomCompleter;
   private XWikiContext context;
   private DocumentAccessBridge docAccessBridgeMock;
 
   @Before
-  public void setUp_EntityReferenceRandomCompleterTest() throws Exception {
+  public void prepareTest() throws Exception {
     docAccessBridgeMock = registerComponentMock(DocumentAccessBridge.class);
     context = getContext();
     randomCompleter = (EntityReferenceRandomCompleter) Utils.getComponent(


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-803
- moved `com.celements.auth.user` interfaces from core to model (new files)
- using `User` in ModelContext
- extended `User` with methods `isGlobal`, `getType`, `getXName`
- included some refactorings where I moved and refactored several rights check methods from WebUtils to RightsAccess. please review those more carefully.