### PR TITLE
Resolve cyclic dependency

### DIFF
--- a/celements-component/pom.xml
+++ b/celements-component/pom.xml
@@ -24,12 +24,15 @@
       <artifactId>xwiki-core-shared-tests</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- This dependency introduces a cycle:
+            ->{celements-common-test, celements-xwiki-core, celements-component}
     <dependency>
       <groupId>com.celements</groupId>
       <artifactId>celements-shared-tests</artifactId>
       <version>5.0-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
+    -->
   </dependencies>
   <scm>
     <connection>scm:git:git@github.com:celements/celements-xwiki.git</connection>

--- a/celements-component/pom.xml
+++ b/celements-component/pom.xml
@@ -24,15 +24,12 @@
       <artifactId>xwiki-core-shared-tests</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- This dependency introduces a cycle:
-            ->{celements-common-test, celements-xwiki-core, celements-component}
     <dependency>
       <groupId>com.celements</groupId>
       <artifactId>celements-shared-tests</artifactId>
       <version>5.0-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
-    -->
   </dependencies>
   <scm>
     <connection>scm:git:git@github.com:celements/celements-xwiki.git</connection>

--- a/celements-xwiki-core/pom.xml
+++ b/celements-xwiki-core/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>com.xpn.xwiki.platform</groupId>
       <artifactId>xwiki-core</artifactId>
-      <scope>provided</scope>
+      <!-- must be scope:compile (default) for completeness -->
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/celements-xwiki-core/pom.xml
+++ b/celements-xwiki-core/pom.xml
@@ -33,6 +33,12 @@
   <dependencies>
     <!-- Add here all your dependencies -->
     <dependency>
+      <groupId>com.celements</groupId>
+      <artifactId>celements-component</artifactId>
+      <version>5.1-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.xpn.xwiki.platform</groupId>
       <artifactId>xwiki-core</artifactId>
       <!-- must be scope:compile (default) for completeness -->

--- a/celements-xwiki-core/pom.xml
+++ b/celements-xwiki-core/pom.xml
@@ -33,14 +33,9 @@
   <dependencies>
     <!-- Add here all your dependencies -->
     <dependency>
-      <groupId>com.celements</groupId>
-      <artifactId>celements-component</artifactId>
-      <version>5.1-SNAPSHOT</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>com.xpn.xwiki.platform</groupId>
       <artifactId>xwiki-core</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -115,6 +110,30 @@
       <scope>test</scope>
     </dependency>
 
+    <!--
+      Make sure we provide a default implementation of slf4j for any test
+      indirectly use it
+    -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -312,6 +331,24 @@
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-core-shared-tests</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit-dep</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
```
One or more cycles were detected in the build path of project 'celements-common-test'. The paths towards the cycle and cycle are:
  ->{celements-common-test, celements-component}
  ->{celements-common-test, celements-xwiki-core, celements-component}
```
For the moment I commented out the dependency `celements-common-test` in `celements-component` since we don't need it **currently**. However we definitely want to use it in the near future, thus we need to come up with a solution for this issue.