### PR TITLE
fix getExistCacheCapacity

### DIFF
--- a/celements-model/src/main/java/com/celements/store/DocumentCacheStore.java
+++ b/celements-model/src/main/java/com/celements/store/DocumentCacheStore.java
@@ -144,11 +144,12 @@ public class DocumentCacheStore extends DelegateStore implements XWikiCacheStore
     LRUEvictionConfiguration lru = new LRUEvictionConfiguration();
     lru.setMaxEntries(getExistCacheCapacity());
     config.put(EntryEvictionConfiguration.CONFIGURATIONID, lru);
+    LOGGER.info("newExistCache - capacity '{}'", lru.getMaxEntries());
     return cacheManager.getCacheFactory().newCache(config);
   }
 
   private int getExistCacheCapacity() {
-    int existCacheCapacity = cfgSrc.getProperty(PARAM_DOC_CACHE_CAPACITY, 10000);
+    int existCacheCapacity = cfgSrc.getProperty(PARAM_EXIST_CACHE_CAPACITY, 10000);
     int docCacheCapacity = getDocCacheCapacity();
     if (existCacheCapacity < docCacheCapacity) {
       LOGGER.warn("WARNING: document exists cache capacity is smaller configured than docCache "
@@ -165,6 +166,7 @@ public class DocumentCacheStore extends DelegateStore implements XWikiCacheStore
     LRUEvictionConfiguration lru = new LRUEvictionConfiguration();
     lru.setMaxEntries(getDocCacheCapacity());
     config.put(EntryEvictionConfiguration.CONFIGURATIONID, lru);
+    LOGGER.info("newDocCache - capacity '{}'", lru.getMaxEntries());
     return cacheManager.getCacheFactory().newCache(config);
   }
 


### PR DESCRIPTION
exists cache capacity equals doc cache capacity since celements 5.9

https://github.com/celements/celements-base/pull/185/changes#diff-4b6e58f907ed39c3070ac889dfeeb88ec5f4d307dc6ac5d91589d8f493be0554R149
