### PR TITLE
CELDEV-1313 - Migrates mail dependencies from legacy javax.mail to Jakarta Mail

### DIFF
--- a/celements-xwiki-core/pom.xml
+++ b/celements-xwiki-core/pom.xml
@@ -350,8 +350,8 @@
     </dependency>
     <!-- Mail sender -->
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>jakarta.mail</artifactId>
     </dependency>
     <!-- Used by another tool, it should be removed some time -->
     <dependency>

--- a/celements-xwiki-core/src/main/java/com/xpn/xwiki/plugin/mail/MailPluginApi.java
+++ b/celements-xwiki-core/src/main/java/com/xpn/xwiki/plugin/mail/MailPluginApi.java
@@ -23,12 +23,12 @@ package com.xpn.xwiki.plugin.mail;
 
 import java.util.Properties;
 
-import javax.mail.FetchProfile;
-import javax.mail.Folder;
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.Store;
+import jakarta.mail.FetchProfile;
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.api.Api;


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-1313

**Migrates mail dependencies from legacy `javax.mail` to Jakarta Mail.**
- Adds managed `com.sun.mail:jakarta.mail:2.0.2` in `base-pom`
- Replaces `javax.mail:mail` in `celements-xwiki-core`
- Updates mail imports in core and mailsender to `jakarta.mail` / `jakarta.activation`
- Ensures generated bytecode calls `MimeBodyPart.setDataHandler(jakarta.activation.DataHandler)`, fixing the production `NoSuchMethodError`
- Verified `celements-xwiki-core` and `celements-mailsender` compile, and `celements-webapp` no longer resolves `mail-1.4.jar`