### PR TITLE
CELDEV-1304 - add PageAttachmentController as backend for PageAttachments app script

### DIFF
--- a/celements-filebase/src/main/java/com/celements/filebase/AttachmentRequest.java
+++ b/celements-filebase/src/main/java/com/celements/filebase/AttachmentRequest.java
@@ -1,0 +1,6 @@
+package com.celements.filebase;
+
+import org.xwiki.model.reference.DocumentReference;
+
+record AttachmentRequest(DocumentReference docRef, String dirPath) {
+}

--- a/celements-filebase/src/main/java/com/celements/filebase/FileItemHelper.java
+++ b/celements-filebase/src/main/java/com/celements/filebase/FileItemHelper.java
@@ -1,0 +1,76 @@
+package com.celements.filebase;
+
+import java.net.URLConnection;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Objects;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.xwiki.model.reference.AttachmentReference;
+
+import com.celements.filebase.dto.FileItem;
+import com.celements.model.reference.RefBuilder;
+import com.celements.url.UrlService;
+import com.xpn.xwiki.doc.XWikiAttachment;
+
+@Component
+public class FileItemHelper {
+
+  private static final int MAX_WIDTH = 800;
+  private static final int MAX_HEIGHT = 800;
+
+  private final UrlService urlService;
+
+  public FileItemHelper(UrlService urlService) {
+    this.urlService = Objects.requireNonNull(urlService);
+  }
+
+  public FileItem toFileItem(String dirPath, XWikiAttachment att, String storage) {
+    String name = att.getFilename();
+    AttachmentReference attachmentRef = RefBuilder.from(att.getDoc().getDocumentReference())
+        .att(name).build(AttachmentReference.class);
+    String query = "celwidth=" + MAX_WIDTH + "&celheight=" + MAX_HEIGHT;
+    return new FileItem(
+        dirPath,
+        name,
+        extensionOf(name),
+        dirPath.endsWith("/") ? (dirPath + name) : (dirPath + "/" + name),
+        urlService.getURL(attachmentRef, "download"),
+        urlService.getURL(attachmentRef, "download", query),
+        storage,
+        "file",
+        (long) att.getFilesize(),
+        toUnixSeconds(att.getDate()),
+        guessMimeType(name),
+        "public");
+  }
+
+  public String guessMimeType(String filename) {
+    String mime = URLConnection.guessContentTypeFromName(filename);
+    return mime != null ? mime : "application/octet-stream";
+  }
+
+  public String extensionOf(String name) {
+    int i = name.lastIndexOf('.');
+    return (i > 0) && (i < (name.length() - 1)) ? name.substring(i + 1).toLowerCase(Locale.ROOT)
+        : "";
+  }
+
+  public long toUnixSeconds(Date date) {
+    if (date == null) {
+      return Instant.now().getEpochSecond();
+    }
+    return date.toInstant().getEpochSecond();
+  }
+
+  public String normalizeFileName(String path) {
+    String p = StringUtils.hasText(path) ? path.trim() : "";
+    int lastSlash = p.lastIndexOf('/');
+    if (lastSlash >= 0) {
+      return p.substring(lastSlash + 1);
+    }
+    return p;
+  }
+}

--- a/celements-filebase/src/main/java/com/celements/filebase/MediaLibController.java
+++ b/celements-filebase/src/main/java/com/celements/filebase/MediaLibController.java
@@ -2,10 +2,8 @@ package com.celements.filebase;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URLConnection;
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -29,10 +27,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
-import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
 
 import com.celements.auth.user.User;
@@ -56,28 +52,23 @@ import com.celements.model.access.IModelAccessFacade;
 import com.celements.model.access.exception.DocumentSaveException;
 import com.celements.model.context.ModelContext;
 import com.celements.model.object.xwiki.XWikiObjectEditor;
-import com.celements.model.reference.RefBuilder;
 import com.celements.model.util.ModelUtils;
 import com.celements.rights.access.EAccessLevel;
 import com.celements.rights.access.IRightsAccessFacadeRole;
 import com.celements.spring.security.AuthenticatedBaseController;
-import com.celements.url.UrlService;
 import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.doc.XWikiDocument;
 
 @RestController
-@RestControllerAdvice
 @RequestMapping("/files")
 public class MediaLibController extends AuthenticatedBaseController {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MediaLibController.class);
 
   private static final String STORAGE = "local";
-  private static final int MAX_WIDTH = 800;
-  private static final int MAX_HEIGHT = 800;
 
   private final IFileBaseServiceRole fileBaseService;
-  private final UrlService urlService;
+  private final FileItemHelper fileItemHelper;
   private final IModelAccessFacade modelAccess;
   private final IRightsAccessFacadeRole rightsAccess;
   private final ModelUtils modelUtils;
@@ -86,17 +77,17 @@ public class MediaLibController extends AuthenticatedBaseController {
   @Inject
   public MediaLibController(
       IFileBaseServiceRole fileBaseService,
-      UrlService urlService,
+      FileItemHelper fileItemHelper,
       IModelAccessFacade modelAccess,
       IRightsAccessFacadeRole rightsAccess,
       ModelUtils modelUtils,
       ModelContext modelContext) {
-    this.fileBaseService = fileBaseService;
-    this.urlService = urlService;
-    this.modelAccess = modelAccess;
-    this.rightsAccess = rightsAccess;
-    this.modelUtils = modelUtils;
-    this.modelContext = modelContext;
+    this.fileBaseService = Objects.requireNonNull(fileBaseService);
+    this.fileItemHelper = Objects.requireNonNull(fileItemHelper);
+    this.modelAccess = Objects.requireNonNull(modelAccess);
+    this.rightsAccess = Objects.requireNonNull(rightsAccess);
+    this.modelUtils = Objects.requireNonNull(modelUtils);
+    this.modelContext = Objects.requireNonNull(modelContext);
   }
 
   /**
@@ -119,7 +110,7 @@ public class MediaLibController extends AuthenticatedBaseController {
       try {
         List<FileItem> files = fileBaseService.getFilesNameMatch(new AllAttachmentMatcher())
             .stream()
-            .map(att -> toFileItem(dirPath, att))
+            .map(att -> fileItemHelper.toFileItem(dirPath, att, STORAGE))
             // enforce XWiki rights (skip what user cannot access)
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
@@ -159,7 +150,7 @@ public class MediaLibController extends AuthenticatedBaseController {
               exp);
         }
       }
-      return java.util.Collections.emptyMap();
+      return Collections.emptyMap();
     }
     throw new ResponseStatusException(HttpStatus.FORBIDDEN);
   }
@@ -170,7 +161,6 @@ public class MediaLibController extends AuthenticatedBaseController {
    * body: { "items": [ { "path": "local://public/FileRepo/a.png", "type":"file" }
    * ] }
    * Response: updated list (same structure as GET /).
-   * :contentReference[oaicite:5]{index=5}
    */
   @PostMapping(path = "/delete")
   @PreAuthorize("permitAll()")
@@ -185,7 +175,7 @@ public class MediaLibController extends AuthenticatedBaseController {
           if ((item == null) || !"file".equalsIgnoreCase(item.type())) {
             continue;
           }
-          String delFileName = normalizeFileName(item.path());
+          String delFileName = fileItemHelper.normalizeFileName(item.path());
           LOGGER.debug("add filename '{}' to delete list", delFileName);
           refs.add(delFileName);
         }
@@ -214,7 +204,7 @@ public class MediaLibController extends AuthenticatedBaseController {
         List<FileItem> files = fileBaseService.getFilesNameMatch(
             att -> att.getFilename().toLowerCase(Locale.ROOT).contains(lower))
             .stream()
-            .map(att -> toFileItem(dirPath, att))
+            .map(att -> fileItemHelper.toFileItem(dirPath, att, STORAGE))
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
         return new ListResponse(List.of(STORAGE), dirPath, false, files);
@@ -256,9 +246,9 @@ public class MediaLibController extends AuthenticatedBaseController {
         .filter(t -> modelUtils.serializeRefLocal(t.getTagRef()).equals(tagId))
         .findFirst()
         .map(FileBaseTag::getTagFileList)
-        .orElse(java.util.Collections.emptyList())
+        .orElse(Collections.emptyList())
         .stream()
-        .map(ref -> normalizeFileName(ref.getName()))
+        .map(ref -> fileItemHelper.normalizeFileName(ref.getName()))
         .collect(Collectors.toList());
     return ResponseEntity.ok(files);
   }
@@ -373,7 +363,7 @@ public class MediaLibController extends AuthenticatedBaseController {
   }
 
   private String toAttachmentKey(String filePath) {
-    String filename = normalizeFileName(filePath);
+    String filename = fileItemHelper.normalizeFileName(filePath);
     try {
       XWikiAttachment att = fileBaseService.getFileNameEqual(filename);
       return modelUtils.serializeRefLocal(att.getDoc().getDocumentReference()) + "/" + filename;
@@ -399,58 +389,12 @@ public class MediaLibController extends AuthenticatedBaseController {
     return p;
   }
 
-  String normalizeFileName(String path) {
-    String p = StringUtils.hasText(path) ? path.trim() : (STORAGE + "://");
-    var parts = p.split("://|/");
-    return parts[Math.max(0, parts.length - 1)];
-  }
-
-  private FileItem toFileItem(String dirPath, XWikiAttachment att) {
-    String name = att.getFilename();
-    AttachmentReference attachmentRef = RefBuilder.from(att.getDoc().getDocumentReference())
-        .att(name).build(AttachmentReference.class);
-    String query = "celwidth=" + MAX_WIDTH + "&celheight=" + MAX_HEIGHT;
-    return new FileItem(
-        dirPath,
-        name,
-        extensionOf(name),
-        dirPath.endsWith("/") ? (dirPath + name) : (dirPath + "/" + name),
-        urlService.getURL(attachmentRef, "download"),
-        urlService.getURL(attachmentRef, "download", query),
-        STORAGE,
-        "file",
-        (long) att.getFilesize(),
-        toUnixSeconds(att.getDate()),
-        guessMimeType(name),
-        "public");
-  }
-
-  private String guessMimeType(String filename) {
-    String mime = URLConnection.guessContentTypeFromName(filename);
-    return (mime != null) ? mime : "application/octet-stream";
-  }
-
-  private String extensionOf(String name) {
-    int i = name.lastIndexOf('.');
-    return ((i > 0) && (i < (name.length() - 1))) ? name.substring(i + 1).toLowerCase(Locale.ROOT)
-        : "";
-  }
-
-  private long toUnixSeconds(Date date) {
-    if (date == null) {
-      return Instant.now().getEpochSecond();
-    }
-    return date.toInstant().getEpochSecond();
-  }
-
-  // inner classes moved to com.celements.filebase.dto package
-
   @ExceptionHandler(ResponseStatusException.class)
   @PreAuthorize("permitAll()")
   public ResponseEntity<?> handle(ResponseStatusException ex) {
     return ResponseEntity
         .status(ex.getStatus())
-        .body(java.util.Map.of("message",
+        .body(Map.of("message",
             ex.getReason() != null ? ex.getReason() : "Request failed"));
   }
 
@@ -477,6 +421,6 @@ public class MediaLibController extends AuthenticatedBaseController {
   private ResponseEntity<?> internalServerError(String message) {
     return ResponseEntity
         .status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .body(java.util.Map.of("message", message));
+        .body(Map.of("message", message));
   }
 }

--- a/celements-filebase/src/main/java/com/celements/filebase/PageAttachmentsController.java
+++ b/celements-filebase/src/main/java/com/celements/filebase/PageAttachmentsController.java
@@ -1,0 +1,276 @@
+package com.celements.filebase;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLConnection;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+import org.xwiki.model.reference.AttachmentReference;
+import org.xwiki.model.reference.DocumentReference;
+
+import com.celements.auth.user.User;
+import com.celements.filebase.dto.DeleteItem;
+import com.celements.filebase.dto.DeleteRequest;
+import com.celements.filebase.dto.FileItem;
+import com.celements.filebase.dto.ListResponse;
+import com.celements.model.access.IModelAccessFacade;
+import com.celements.model.access.exception.DocumentLoadException;
+import com.celements.model.access.exception.DocumentSaveException;
+import com.celements.model.context.ModelContext;
+import com.celements.model.reference.RefBuilder;
+import com.celements.rights.access.EAccessLevel;
+import com.celements.rights.access.IRightsAccessFacadeRole;
+import com.celements.spring.security.AuthenticatedBaseController;
+import com.celements.url.UrlService;
+import com.xpn.xwiki.doc.XWikiAttachment;
+import com.xpn.xwiki.doc.XWikiDocument;
+
+@RestController
+@RestControllerAdvice
+@RequestMapping("/attachments/{spaceName}/{docName}")
+public class PageAttachmentsController extends AuthenticatedBaseController {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PageAttachmentsController.class);
+
+  private static final String STORAGE = "attachments";
+  private static final int MAX_WIDTH = 800;
+  private static final int MAX_HEIGHT = 800;
+
+  private final IAttachmentServiceRole attService;
+  private final UrlService urlService;
+  private final IModelAccessFacade modelAccess;
+  private final IRightsAccessFacadeRole rightsAccess;
+  private final ModelContext modelContext;
+
+  @Inject
+  public PageAttachmentsController(
+      IAttachmentServiceRole attService,
+      UrlService urlService,
+      IModelAccessFacade modelAccess,
+      IRightsAccessFacadeRole rightsAccess,
+      ModelContext modelContext) {
+    this.attService = attService;
+    this.urlService = urlService;
+    this.modelAccess = modelAccess;
+    this.rightsAccess = rightsAccess;
+    this.modelContext = modelContext;
+  }
+
+  @GetMapping("")
+  @PreAuthorize("permitAll()")
+  public ListResponse list(
+      @PathVariable String spaceName,
+      @PathVariable String docName,
+      @RequestParam(name = "path", required = false) String path) {
+    AttachmentRequest request = prepareRequest(spaceName, docName, path, EAccessLevel.VIEW);
+    try {
+      XWikiDocument doc = modelAccess.getOrCreateDocument(request.docRef());
+      List<FileItem> files = attService.getAttachmentsNameMatch(doc, att -> true)
+          .stream()
+          .map(att -> toFileItem(request.dirPath(), att))
+          .filter(Objects::nonNull)
+          .collect(Collectors.toList());
+      return new ListResponse(List.of(STORAGE), request.dirPath(), false, files);
+    } catch (DocumentLoadException exp) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Document load failed", exp);
+    }
+  }
+
+  @PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @PreAuthorize("permitAll()")
+  public Object upload(
+      @PathVariable String spaceName,
+      @PathVariable String docName,
+      @RequestParam("path") String path,
+      @RequestParam("file") List<MultipartFile> files) {
+    AttachmentRequest request = prepareRequest(spaceName, docName, path, EAccessLevel.EDIT);
+    try {
+      XWikiDocument doc = modelAccess.getOrCreateDocument(request.docRef());
+      for (MultipartFile file : files) {
+        if ((file == null) || file.isEmpty()) {
+          continue;
+        }
+        String original = file.getOriginalFilename();
+        String fileName = StringUtils.hasText(original) ? original : "upload.bin";
+        String safeName = attService.clearFileName(fileName);
+        try (InputStream in = file.getInputStream()) {
+          attService.addAttachment(doc, in, safeName, null, "Uploaded via VueFinder");
+        } catch (IOException | AttachmentToBigException | AddingAttachmentContentFailedException exp) {
+          throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Fileupload failed.",
+              exp);
+        }
+      }
+      return java.util.Collections.emptyMap();
+    } catch (DocumentLoadException | DocumentSaveException exp) {
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Fileupload failed.", exp);
+    }
+  }
+
+  @PostMapping("/delete")
+  @PreAuthorize("permitAll()")
+  public ListResponse delete(
+      @PathVariable String spaceName,
+      @PathVariable String docName,
+      @RequestBody DeleteRequest body) {
+    AttachmentRequest request = prepareRequest(spaceName, docName, body.path(), EAccessLevel.DELETE);
+    try {
+      XWikiDocument doc = modelAccess.getOrCreateDocument(request.docRef());
+      List<AttachmentReference> attsToDelete = new ArrayList<>();
+      if (body.items() != null) {
+        for (DeleteItem item : body.items()) {
+          if (item == null || !"file".equalsIgnoreCase(item.type())) {
+            continue;
+          }
+          String delFileName = normalizeFileName(item.path());
+          if (attService.existsAttachmentNameEqual(doc, delFileName)) {
+            attsToDelete.add(new AttachmentReference(delFileName, request.docRef()));
+          }
+        }
+      }
+      if (!attsToDelete.isEmpty()) {
+        attService.deleteAttachmentList(attsToDelete);
+      }
+      return list(spaceName, docName, body.path());
+    } catch (DocumentLoadException exp) {
+      throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Delete failed.", exp);
+    }
+  }
+
+  @GetMapping("/search")
+  @PreAuthorize("permitAll()")
+  public ListResponse search(
+      @PathVariable String spaceName,
+      @PathVariable String docName,
+      @RequestParam("q") String query,
+      @RequestParam(name = "path", required = false) String path) {
+    AttachmentRequest request = prepareRequest(spaceName, docName, path, EAccessLevel.VIEW);
+    String lower = query.toLowerCase(Locale.ROOT);
+    try {
+      XWikiDocument doc = modelAccess.getOrCreateDocument(request.docRef());
+      List<FileItem> files = attService.getAttachmentsNameMatch(doc,
+          att -> att.getFilename().toLowerCase(Locale.ROOT).contains(lower))
+          .stream()
+          .map(att -> toFileItem(request.dirPath(), att))
+          .filter(Objects::nonNull)
+          .collect(Collectors.toList());
+      return new ListResponse(List.of(STORAGE), request.dirPath(), false, files);
+    } catch (DocumentLoadException exp) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Search failed", exp);
+    }
+  }
+
+  private AttachmentRequest prepareRequest(
+      String spaceName,
+      String docName,
+      String path,
+      EAccessLevel accessLevel) {
+    checkAuth();
+    User user = modelContext.user().orElse(null);
+    if (user == null) {
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+    }
+    DocumentReference docRef = RefBuilder.create()
+        .with(modelContext.getWikiRef())
+        .space(spaceName)
+        .doc(docName)
+        .build(DocumentReference.class);
+    if (!rightsAccess.hasAccessLevel(docRef, accessLevel, user)) {
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN);
+    }
+    return new AttachmentRequest(docRef, normalizeDirPath(spaceName, docName, path));
+  }
+
+  private String normalizeDirPath(String spaceName, String docName, String path) {
+    String expectedPrefix = STORAGE + "://" + spaceName + "/" + docName;
+    String p = StringUtils.hasText(path) ? path.trim() : expectedPrefix;
+    if (!p.startsWith(STORAGE + "://")) {
+      p = expectedPrefix + "/" + p;
+    }
+    if (p.endsWith("/") && !p.equals(expectedPrefix)) {
+      p = p.substring(0, p.length() - 1);
+    }
+    return p;
+  }
+
+  String normalizeFileName(String path) {
+    String p = StringUtils.hasText(path) ? path.trim() : "";
+    int lastSlash = p.lastIndexOf('/');
+    if (lastSlash >= 0) {
+      return p.substring(lastSlash + 1);
+    }
+    return p;
+  }
+
+  private FileItem toFileItem(String dirPath, XWikiAttachment att) {
+    String name = att.getFilename();
+    AttachmentReference attachmentRef = RefBuilder.from(att.getDoc().getDocumentReference())
+        .att(name).build(AttachmentReference.class);
+    String query = "celwidth=" + MAX_WIDTH + "&celheight=" + MAX_HEIGHT;
+    return new FileItem(
+        dirPath,
+        name,
+        extensionOf(name),
+        dirPath.endsWith("/") ? (dirPath + name) : (dirPath + "/" + name),
+        urlService.getURL(attachmentRef, "download"),
+        urlService.getURL(attachmentRef, "download", query),
+        STORAGE,
+        "file",
+        (long) att.getFilesize(),
+        toUnixSeconds(att.getDate()),
+        guessMimeType(name),
+        "public");
+  }
+
+  private String guessMimeType(String filename) {
+    String mime = URLConnection.guessContentTypeFromName(filename);
+    return (mime != null) ? mime : "application/octet-stream";
+  }
+
+  private String extensionOf(String name) {
+    int i = name.lastIndexOf('.');
+    return ((i > 0) && (i < (name.length() - 1))) ? name.substring(i + 1).toLowerCase(Locale.ROOT)
+        : "";
+  }
+
+  private long toUnixSeconds(Date date) {
+    if (date == null) {
+      return Instant.now().getEpochSecond();
+    }
+    return date.toInstant().getEpochSecond();
+  }
+
+  @ExceptionHandler(ResponseStatusException.class)
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<?> handle(ResponseStatusException ex) {
+    return ResponseEntity
+        .status(ex.getStatus())
+        .body(java.util.Map.of("message",
+            ex.getReason() != null ? ex.getReason() : "Request failed"));
+  }
+}

--- a/celements-filebase/src/main/java/com/celements/filebase/PageAttachmentsController.java
+++ b/celements-filebase/src/main/java/com/celements/filebase/PageAttachmentsController.java
@@ -2,16 +2,16 @@ package com.celements.filebase;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URLConnection;
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,6 +20,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.util.StringUtils;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,8 +29,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.multipart.MultipartHttpServletRequest;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.server.ResponseStatusException;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
@@ -43,27 +45,21 @@ import com.celements.model.access.IModelAccessFacade;
 import com.celements.model.access.exception.DocumentLoadException;
 import com.celements.model.access.exception.DocumentSaveException;
 import com.celements.model.context.ModelContext;
-import com.celements.model.reference.RefBuilder;
 import com.celements.rights.access.EAccessLevel;
 import com.celements.rights.access.IRightsAccessFacadeRole;
 import com.celements.spring.security.AuthenticatedBaseController;
-import com.celements.url.UrlService;
-import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.doc.XWikiDocument;
 
 @RestController
-@RestControllerAdvice
 @RequestMapping("/attachments/{spaceName}/{docName}")
 public class PageAttachmentsController extends AuthenticatedBaseController {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PageAttachmentsController.class);
 
   private static final String STORAGE = "attachments";
-  private static final int MAX_WIDTH = 800;
-  private static final int MAX_HEIGHT = 800;
 
   private final IAttachmentServiceRole attService;
-  private final UrlService urlService;
+  private final FileItemHelper fileItemHelper;
   private final IModelAccessFacade modelAccess;
   private final IRightsAccessFacadeRole rightsAccess;
   private final ModelContext modelContext;
@@ -71,15 +67,15 @@ public class PageAttachmentsController extends AuthenticatedBaseController {
   @Inject
   public PageAttachmentsController(
       IAttachmentServiceRole attService,
-      UrlService urlService,
+      FileItemHelper fileItemHelper,
       IModelAccessFacade modelAccess,
       IRightsAccessFacadeRole rightsAccess,
       ModelContext modelContext) {
-    this.attService = attService;
-    this.urlService = urlService;
-    this.modelAccess = modelAccess;
-    this.rightsAccess = rightsAccess;
-    this.modelContext = modelContext;
+    this.attService = Objects.requireNonNull(attService);
+    this.fileItemHelper = Objects.requireNonNull(fileItemHelper);
+    this.modelAccess = Objects.requireNonNull(modelAccess);
+    this.rightsAccess = Objects.requireNonNull(rightsAccess);
+    this.modelContext = Objects.requireNonNull(modelContext);
   }
 
   @GetMapping("")
@@ -93,7 +89,7 @@ public class PageAttachmentsController extends AuthenticatedBaseController {
       XWikiDocument doc = modelAccess.getOrCreateDocument(request.docRef());
       List<FileItem> files = attService.getAttachmentsNameMatch(doc, att -> true)
           .stream()
-          .map(att -> toFileItem(request.dirPath(), att))
+          .map(att -> fileItemHelper.toFileItem(request.dirPath(), att, STORAGE))
           .filter(Objects::nonNull)
           .collect(Collectors.toList());
       return new ListResponse(List.of(STORAGE), request.dirPath(), false, files);
@@ -126,7 +122,7 @@ public class PageAttachmentsController extends AuthenticatedBaseController {
               exp);
         }
       }
-      return java.util.Collections.emptyMap();
+      return Collections.emptyMap();
     } catch (DocumentLoadException | DocumentSaveException exp) {
       throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Fileupload failed.", exp);
     }
@@ -147,7 +143,7 @@ public class PageAttachmentsController extends AuthenticatedBaseController {
           if (item == null || !"file".equalsIgnoreCase(item.type())) {
             continue;
           }
-          String delFileName = normalizeFileName(item.path());
+          String delFileName = fileItemHelper.normalizeFileName(item.path());
           if (attService.existsAttachmentNameEqual(doc, delFileName)) {
             attsToDelete.add(new AttachmentReference(delFileName, request.docRef()));
           }
@@ -176,7 +172,7 @@ public class PageAttachmentsController extends AuthenticatedBaseController {
       List<FileItem> files = attService.getAttachmentsNameMatch(doc,
           att -> att.getFilename().toLowerCase(Locale.ROOT).contains(lower))
           .stream()
-          .map(att -> toFileItem(request.dirPath(), att))
+          .map(att -> fileItemHelper.toFileItem(request.dirPath(), att, STORAGE))
           .filter(Objects::nonNull)
           .collect(Collectors.toList());
       return new ListResponse(List.of(STORAGE), request.dirPath(), false, files);
@@ -195,11 +191,9 @@ public class PageAttachmentsController extends AuthenticatedBaseController {
     if (user == null) {
       throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
     }
-    DocumentReference docRef = RefBuilder.create()
-        .with(modelContext.getWikiRef())
-        .space(spaceName)
-        .doc(docName)
-        .build(DocumentReference.class);
+    DocumentReference docRef = new DocumentReference(
+        docName,
+        new org.xwiki.model.reference.SpaceReference(spaceName, modelContext.getWikiRef()));
     if (!rightsAccess.hasAccessLevel(docRef, accessLevel, user)) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN);
     }
@@ -218,81 +212,27 @@ public class PageAttachmentsController extends AuthenticatedBaseController {
     return p;
   }
 
-  String normalizeFileName(String path) {
-    String p = StringUtils.hasText(path) ? path.trim() : "";
-    int lastSlash = p.lastIndexOf('/');
-    if (lastSlash >= 0) {
-      return p.substring(lastSlash + 1);
-    }
-    return p;
-  }
-
-  private FileItem toFileItem(String dirPath, XWikiAttachment att) {
-    String name = att.getFilename();
-    AttachmentReference attachmentRef = RefBuilder.from(att.getDoc().getDocumentReference())
-        .att(name).build(AttachmentReference.class);
-    String query = "celwidth=" + MAX_WIDTH + "&celheight=" + MAX_HEIGHT;
-    return new FileItem(
-        dirPath,
-        name,
-        extensionOf(name),
-        dirPath.endsWith("/") ? (dirPath + name) : (dirPath + "/" + name),
-        urlService.getURL(attachmentRef, "download"),
-        urlService.getURL(attachmentRef, "download", query),
-        STORAGE,
-        "file",
-        (long) att.getFilesize(),
-        toUnixSeconds(att.getDate()),
-        guessMimeType(name),
-        "public");
-  }
-
-  private String guessMimeType(String filename) {
-    String mime = URLConnection.guessContentTypeFromName(filename);
-    return (mime != null) ? mime : "application/octet-stream";
-  }
-
-  private String extensionOf(String name) {
-    int i = name.lastIndexOf('.');
-    return ((i > 0) && (i < (name.length() - 1))) ? name.substring(i + 1).toLowerCase(Locale.ROOT)
-        : "";
-  }
-
-  private long toUnixSeconds(Date date) {
-    if (date == null) {
-      return Instant.now().getEpochSecond();
-    }
-    return date.toInstant().getEpochSecond();
-  }
-
   @ExceptionHandler(ResponseStatusException.class)
   @PreAuthorize("permitAll()")
   public ResponseEntity<?> handle(ResponseStatusException ex) {
     return ResponseEntity
         .status(ex.getStatus())
-        .body(java.util.Map.of("message",
+        .body(Map.of("message",
             ex.getReason() != null ? ex.getReason() : "Request failed"));
   }
 
   @ExceptionHandler({
-      org.springframework.web.bind.MissingServletRequestParameterException.class,
-      org.springframework.web.multipart.support.MissingServletRequestPartException.class
+      MissingServletRequestParameterException.class,
+      MissingServletRequestPartException.class
   })
   @PreAuthorize("permitAll()")
   public ResponseEntity<?> handleMissingParams(
       Exception ex,
-      javax.servlet.http.HttpServletRequest request) {
+      HttpServletRequest request) {
     LOGGER.warn("Missing parameter/part: {}, Request URI: {}, Content-Type: {}",
         ex.getMessage(), request.getRequestURI(), request.getContentType());
-    java.util.Enumeration<String> headerNames = request.getHeaderNames();
-    while (headerNames.hasMoreElements()) {
-      String headerName = headerNames.nextElement();
-      LOGGER.warn("Header {}: {}", headerName, request.getHeader(headerName));
-    }
     try {
-      if (request instanceof org.springframework.web.multipart.MultipartHttpServletRequest) {
-        org.springframework.web.multipart.MultipartHttpServletRequest multipartRequest =
-            (org.springframework.web.multipart.MultipartHttpServletRequest) request;
+      if (request instanceof MultipartHttpServletRequest multipartRequest) {
         LOGGER.warn("Multipart parameter names: {}", multipartRequest.getParameterMap().keySet());
         LOGGER.warn("Multipart file names: {}", multipartRequest.getFileMap().keySet());
       } else {
@@ -304,6 +244,6 @@ public class PageAttachmentsController extends AuthenticatedBaseController {
     }
     return ResponseEntity
         .status(HttpStatus.BAD_REQUEST)
-        .body(java.util.Map.of("message", ex.getMessage()));
+        .body(Map.of("message", ex.getMessage()));
   }
 }

--- a/celements-filebase/src/main/java/com/celements/filebase/PageAttachmentsController.java
+++ b/celements-filebase/src/main/java/com/celements/filebase/PageAttachmentsController.java
@@ -107,7 +107,7 @@ public class PageAttachmentsController extends AuthenticatedBaseController {
   public Object upload(
       @PathVariable String spaceName,
       @PathVariable String docName,
-      @RequestParam("path") String path,
+      @RequestParam(name = "path", required = false) String path,
       @RequestParam("file") List<MultipartFile> files) {
     AttachmentRequest request = prepareRequest(spaceName, docName, path, EAccessLevel.EDIT);
     try {
@@ -272,5 +272,38 @@ public class PageAttachmentsController extends AuthenticatedBaseController {
         .status(ex.getStatus())
         .body(java.util.Map.of("message",
             ex.getReason() != null ? ex.getReason() : "Request failed"));
+  }
+
+  @ExceptionHandler({
+      org.springframework.web.bind.MissingServletRequestParameterException.class,
+      org.springframework.web.multipart.support.MissingServletRequestPartException.class
+  })
+  @PreAuthorize("permitAll()")
+  public ResponseEntity<?> handleMissingParams(
+      Exception ex,
+      javax.servlet.http.HttpServletRequest request) {
+    LOGGER.warn("Missing parameter/part: {}, Request URI: {}, Content-Type: {}",
+        ex.getMessage(), request.getRequestURI(), request.getContentType());
+    java.util.Enumeration<String> headerNames = request.getHeaderNames();
+    while (headerNames.hasMoreElements()) {
+      String headerName = headerNames.nextElement();
+      LOGGER.warn("Header {}: {}", headerName, request.getHeader(headerName));
+    }
+    try {
+      if (request instanceof org.springframework.web.multipart.MultipartHttpServletRequest) {
+        org.springframework.web.multipart.MultipartHttpServletRequest multipartRequest =
+            (org.springframework.web.multipart.MultipartHttpServletRequest) request;
+        LOGGER.warn("Multipart parameter names: {}", multipartRequest.getParameterMap().keySet());
+        LOGGER.warn("Multipart file names: {}", multipartRequest.getFileMap().keySet());
+      } else {
+        LOGGER.warn("Request is not a MultipartHttpServletRequest. Parameter names: {}",
+            request.getParameterMap().keySet());
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Failed to log request details", e);
+    }
+    return ResponseEntity
+        .status(HttpStatus.BAD_REQUEST)
+        .body(java.util.Map.of("message", ex.getMessage()));
   }
 }

--- a/celements-filebase/src/test/java/com/celements/filebase/MediaLibControllerTest.java
+++ b/celements-filebase/src/test/java/com/celements/filebase/MediaLibControllerTest.java
@@ -25,6 +25,7 @@ import com.xpn.xwiki.user.api.XWikiUser;
 public class MediaLibControllerTest extends AbstractComponentTest {
 
   private MediaLibController mediaLibCtrl;
+  private FileItemHelper fileItemHelper;
   private IFileBaseServiceRole fileBaseServiceMock;
   private ModelContext modelContextMock;
   private UserService userServiceMock;
@@ -38,18 +39,19 @@ public class MediaLibControllerTest extends AbstractComponentTest {
     modelContextMock = registerComponentMock(ModelContext.class);
     userServiceMock = registerComponentMock(UserService.class);
     userMock = createDefaultMock(User.class);
+    fileItemHelper = getBeanFactory().getBean(FileItemHelper.class);
     mediaLibCtrl = getBeanFactory().getBean(MediaLibController.class);
   }
 
   @Test
   public void testNormalizeFileName_file() {
-    String fileName = mediaLibCtrl.normalizeFileName("local://IMG-20250606-WA0000.jpg");
+    String fileName = fileItemHelper.normalizeFileName("local://IMG-20250606-WA0000.jpg");
     assertEquals("IMG-20250606-WA0000.jpg", fileName);
   }
 
   @Test
   public void testNormalizeFileName_subPath() {
-    String fileName = mediaLibCtrl.normalizeFileName("local://test/IMG-20250606-WA0000.jpg");
+    String fileName = fileItemHelper.normalizeFileName("local://test/IMG-20250606-WA0000.jpg");
     assertEquals("IMG-20250606-WA0000.jpg", fileName);
   }
 

--- a/celements-filebase/src/test/java/com/celements/filebase/PageAttachmentsControllerTest.java
+++ b/celements-filebase/src/test/java/com/celements/filebase/PageAttachmentsControllerTest.java
@@ -35,6 +35,7 @@ import com.xpn.xwiki.user.api.XWikiUser;
 public class PageAttachmentsControllerTest extends AbstractComponentTest {
 
   private PageAttachmentsController pageAttachmentsCtrl;
+  private FileItemHelper fileItemHelper;
   private IAttachmentServiceRole attServiceMock;
   private UrlService urlServiceMock;
   private IModelAccessFacade modelAccessMock;
@@ -54,12 +55,13 @@ public class PageAttachmentsControllerTest extends AbstractComponentTest {
     modelContextMock = registerComponentMock(ModelContext.class);
     userServiceMock = registerComponentMock(UserService.class);
     userMock = createDefaultMock(User.class);
+    fileItemHelper = getBeanFactory().getBean(FileItemHelper.class);
     pageAttachmentsCtrl = getBeanFactory().getBean(PageAttachmentsController.class);
   }
 
   @Test
   public void testNormalizeFileName_file() {
-    String fileName = pageAttachmentsCtrl.normalizeFileName("attachments://MySpace/MyDoc/IMG.jpg");
+    String fileName = fileItemHelper.normalizeFileName("attachments://MySpace/MyDoc/IMG.jpg");
     assertEquals("IMG.jpg", fileName);
   }
 

--- a/celements-filebase/src/test/java/com/celements/filebase/PageAttachmentsControllerTest.java
+++ b/celements-filebase/src/test/java/com/celements/filebase/PageAttachmentsControllerTest.java
@@ -1,0 +1,179 @@
+package com.celements.filebase;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.server.ResponseStatusException;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.SpaceReference;
+import org.xwiki.model.reference.WikiReference;
+
+import com.celements.auth.user.User;
+import com.celements.auth.user.UserService;
+import com.celements.common.test.AbstractComponentTest;
+import com.celements.filebase.dto.DeleteItem;
+import com.celements.filebase.dto.DeleteRequest;
+import com.celements.filebase.dto.ListResponse;
+import com.celements.model.access.IModelAccessFacade;
+import com.celements.model.context.ModelContext;
+import com.celements.rights.access.EAccessLevel;
+import com.celements.rights.access.IRightsAccessFacadeRole;
+import com.celements.url.UrlService;
+import com.xpn.xwiki.doc.XWikiAttachment;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.user.api.XWikiUser;
+
+public class PageAttachmentsControllerTest extends AbstractComponentTest {
+
+  private PageAttachmentsController pageAttachmentsCtrl;
+  private IAttachmentServiceRole attServiceMock;
+  private UrlService urlServiceMock;
+  private IModelAccessFacade modelAccessMock;
+  private IRightsAccessFacadeRole rightsAccessMock;
+  private ModelContext modelContextMock;
+  private UserService userServiceMock;
+  private User userMock;
+
+  @Before
+  public void prepare() throws Exception {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new TestingAuthenticationToken("test", "n/a", "ROLE_USER"));
+    attServiceMock = registerComponentMock(IAttachmentServiceRole.class);
+    urlServiceMock = registerComponentMock(UrlService.class);
+    modelAccessMock = registerComponentMock(IModelAccessFacade.class);
+    rightsAccessMock = registerComponentMock(IRightsAccessFacadeRole.class);
+    modelContextMock = registerComponentMock(ModelContext.class);
+    userServiceMock = registerComponentMock(UserService.class);
+    userMock = createDefaultMock(User.class);
+    pageAttachmentsCtrl = getBeanFactory().getBean(PageAttachmentsController.class);
+  }
+
+  @Test
+  public void testNormalizeFileName_file() {
+    String fileName = pageAttachmentsCtrl.normalizeFileName("attachments://MySpace/MyDoc/IMG.jpg");
+    assertEquals("IMG.jpg", fileName);
+  }
+
+  @Test
+  public void test_list_allowed() throws Exception {
+    expectCheckAuth();
+    expect(modelContextMock.user()).andReturn(Optional.of(userMock)).anyTimes();
+    WikiReference wikiRef = new WikiReference("xwiki");
+    expect(modelContextMock.getWikiRef()).andReturn(wikiRef).anyTimes();
+
+    DocumentReference docRef = new DocumentReference("MyDoc", new SpaceReference("MySpace", wikiRef));
+    expect(rightsAccessMock.hasAccessLevel(eq(docRef), eq(EAccessLevel.VIEW), same(userMock))).andReturn(true);
+
+    XWikiDocument docMock = createDefaultMock(XWikiDocument.class);
+    expect(modelAccessMock.getOrCreateDocument(eq(docRef))).andReturn(docMock);
+
+    XWikiAttachment attMock = createDefaultMock(XWikiAttachment.class);
+    expect(attMock.getFilename()).andReturn("file.png").anyTimes();
+    expect(attMock.getDoc()).andReturn(docMock).anyTimes();
+    expect(attMock.getFilesize()).andReturn(100).anyTimes();
+    expect(attMock.getDate()).andReturn(new Date()).anyTimes();
+
+    expect(attServiceMock.getAttachmentsNameMatch(same(docMock), anyObject())).andReturn(List.of(attMock));
+    expect(docMock.getDocumentReference()).andReturn(docRef).anyTimes();
+    expect(urlServiceMock.getURL(anyObject(), eq("download"))).andReturn("http://download");
+    expect(urlServiceMock.getURL(anyObject(), eq("download"), anyString())).andReturn("http://preview");
+
+    replayDefault();
+    ListResponse response = pageAttachmentsCtrl.list("MySpace", "MyDoc", "attachments://MySpace/MyDoc");
+    verifyDefault();
+
+    assertNotNull(response);
+    assertEquals("attachments://MySpace/MyDoc", response.dirname());
+    assertEquals(1, response.files().size());
+    assertEquals("file.png", response.files().get(0).basename());
+  }
+
+  @Test
+  public void test_list_denied() throws Exception {
+    expectCheckAuth();
+    expect(modelContextMock.user()).andReturn(Optional.of(userMock)).anyTimes();
+    WikiReference wikiRef = new WikiReference("xwiki");
+    expect(modelContextMock.getWikiRef()).andReturn(wikiRef).anyTimes();
+
+    DocumentReference docRef = new DocumentReference("MyDoc", new SpaceReference("MySpace", wikiRef));
+    expect(rightsAccessMock.hasAccessLevel(eq(docRef), eq(EAccessLevel.VIEW), same(userMock))).andReturn(false);
+
+    replayDefault();
+    try {
+      pageAttachmentsCtrl.list("MySpace", "MyDoc", "attachments://MySpace/MyDoc");
+      fail("Expected FORBIDDEN");
+    } catch (ResponseStatusException rse) {
+      assertEquals(HttpStatus.FORBIDDEN, rse.getStatus());
+    }
+    verifyDefault();
+  }
+
+  @Test
+  public void test_search_allowed() throws Exception {
+    expectCheckAuth();
+    expect(modelContextMock.user()).andReturn(Optional.of(userMock)).anyTimes();
+    WikiReference wikiRef = new WikiReference("xwiki");
+    expect(modelContextMock.getWikiRef()).andReturn(wikiRef).anyTimes();
+
+    DocumentReference docRef = new DocumentReference("MyDoc", new SpaceReference("MySpace", wikiRef));
+    expect(rightsAccessMock.hasAccessLevel(eq(docRef), eq(EAccessLevel.VIEW), same(userMock))).andReturn(true);
+
+    XWikiDocument docMock = createDefaultMock(XWikiDocument.class);
+    expect(modelAccessMock.getOrCreateDocument(eq(docRef))).andReturn(docMock);
+
+    expect(attServiceMock.getAttachmentsNameMatch(same(docMock), anyObject())).andReturn(List.of());
+
+    replayDefault();
+    ListResponse response = pageAttachmentsCtrl.search("MySpace", "MyDoc", "test", "attachments://MySpace/MyDoc");
+    verifyDefault();
+
+    assertNotNull(response);
+    assertEquals("attachments://MySpace/MyDoc", response.dirname());
+  }
+
+  @Test
+  public void test_delete_allowed() throws Exception {
+    expectCheckAuth();
+    expect(modelContextMock.user()).andReturn(Optional.of(userMock)).anyTimes();
+    WikiReference wikiRef = new WikiReference("xwiki");
+    expect(modelContextMock.getWikiRef()).andReturn(wikiRef).anyTimes();
+
+    DocumentReference docRef = new DocumentReference("MyDoc", new SpaceReference("MySpace", wikiRef));
+    expect(rightsAccessMock.hasAccessLevel(eq(docRef), eq(EAccessLevel.DELETE), same(userMock))).andReturn(true);
+    expect(rightsAccessMock.hasAccessLevel(eq(docRef), eq(EAccessLevel.VIEW), same(userMock))).andReturn(true);
+
+    XWikiDocument docMock = createDefaultMock(XWikiDocument.class);
+    expect(modelAccessMock.getOrCreateDocument(eq(docRef))).andReturn(docMock).times(2);
+
+    expect(attServiceMock.existsAttachmentNameEqual(same(docMock), eq("a.png"))).andReturn(true);
+    attServiceMock.deleteAttachmentList(anyObject());
+    expectLastCall().andReturn(1);
+
+    expect(attServiceMock.getAttachmentsNameMatch(same(docMock), anyObject())).andReturn(List.of());
+
+    replayDefault();
+
+    DeleteItem item = new DeleteItem("attachments://MySpace/MyDoc/a.png", "file");
+    DeleteRequest request = new DeleteRequest("attachments://MySpace/MyDoc", List.of(item));
+
+    ListResponse response = pageAttachmentsCtrl.delete("MySpace", "MyDoc", request);
+    verifyDefault();
+    assertNotNull(response);
+  }
+
+  private void expectCheckAuth() throws Exception {
+    XWikiUser xuser = new XWikiUser("xwiki:User.test");
+    expect(getXContext().getWiki().checkAuth(same(getXContext()))).andReturn(xuser).anyTimes();
+    expect(userServiceMock.getUser(eq("xwiki:User.test"))).andReturn(userMock).anyTimes();
+  }
+
+}


### PR DESCRIPTION
## Summary

Adds the backend controller for the new Page Attachments app.

This introduces `/attachments/{spaceName}/{docName}` endpoints for listing, searching, uploading, and deleting attachments on a specific page, with authentication, document reference resolution, path normalization, and per-action rights checks.

## Details

- Adds `PageAttachmentsController` for the Page Attachments VueFinder backend.
- Supports listing and searching page attachments with download and preview URLs.
- Supports multipart uploads with filename cleanup.
- Supports attachment deletion via request DTOs.
- Adds top-level record DTOs for `AttachmentRequest`, `DeleteRequest`, and `DeleteItem`.
- Adds controller tests covering filename normalization, list access, denied list access, search, and delete.
